### PR TITLE
Fix: Publish idea-plugin

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -66,3 +66,6 @@ publishing {
 versionsLock {
     disableJavaPluginDefaults()
 }
+
+// Javadoc fails if there are no public classes to javadoc, so make it stop complaining.
+tasks.javadoc.failOnError = false


### PR DESCRIPTION
## Before this PR

Weren't publishing the idea-plugin to bintray.

## After this PR
==COMMIT_MSG==
Now publishing idea-plugin to bintray.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
