### PR TITLE
Use baseline to format ourselves

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,10 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:14.0.0'
         classpath 'com.netflix.nebula:gradle-info-plugin:5.1.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:2.13.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:2.21.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.1.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.12.4'
-        classpath 'com.palantir.javaformat:palantir-java-format:0.0.1'
     }
 }
 
@@ -50,14 +49,5 @@ subprojects {
 
     tasks.withType(Checkstyle) {
         enabled = false
-    }
-
-    spotless {
-        java {
-            customLazyGroovy('palantir-java-format') {
-                Formatter formatter = new Formatter(JavaFormatterOptions.builder().style(JavaFormatterOptions.Style.PALANTIR).build())
-                return { source -> formatter.formatSource(source) }
-            }
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
-com.palantir.baseline-versions.disable = true
+com.palantir.baseline-versions.disable=true
+com.palantir.baseline-format.palantir-java-format=true
 org.gradle.parallel=true
-org.gradle.caching = true
+org.gradle.caching=true


### PR DESCRIPTION
## Before this PR

Were dogfooding the formatter on this project, but in a direct way.
However, now baseline is allowing us to configure this through a simple flag.

## After this PR
==COMMIT_MSG==
Use baseline to format ourselves (using [baseline#936](https://github.com/palantir/gradle-baseline/pull/936)) rather than direct configuration.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

