### PR TITLE
Minimal README with some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ When enabled, it will replace the normal `Reformat Code` action, which can be
 triggered from the `Code` menu or with the Ctrl-Alt-L (by default) keyboard
 shortcut.
 
+## Future works
+
+- [ ] preserve [NON-NLS markers][] - these are comments that are used when implementing NLS internationalisation, and need to stay on the same line with the strings they come after.
+
+[NON-NLS markers]: https://stackoverflow.com/a/40266605
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _A modern, lambda-friendly, 120 character Java formatter._
 - [IntelliJ plugin](https://plugins.jetbrains.com/plugin/13180-palantir-java-format)
 - [Gradle plugin](https://github.com/palantir/gradle-baseline#compalantirbaseline-format)
 
-It is based on the excellent [google-java-format](https://github.com/google/google-java-format), and benefits from the work of all the [original authors](https://github.com/google/google-java-format/graphs/contributors). palantir-java-format is available under the same [Apache 2.0 License](./license).
+It is based on the excellent [google-java-format](https://github.com/google/google-java-format), and benefits from the work of all the [original authors](https://github.com/google/google-java-format/graphs/contributors). palantir-java-format is available under the same [Apache 2.0 License](./LICENSE).
 
 ## Upsides of automatic formatting
 


### PR DESCRIPTION
## Before this PR

We still had quite a lot of stuff from the old google-java-format README, including mentions of an eclipse plugin, instructions to run the jar etc.

## After this PR
==COMMIT_MSG==
README now demonstrates the formatter output, and links to the recommended usages (gradle/intellij)
==COMMIT_MSG==

## Possible downsides?
- a terse readme will probably need to be expanded
- both examples are from the same project (gradle-consistent-versions), which might trigger strong reactions about the _content_ (some people have strong feelings about gradle vs maven) when I actually want them to focus on the _formatting_

