### PR TITLE
Improvement: better inlining of method reference

### DIFF
--- a/changelog/@unreleased/pr-44.v2.yml
+++ b/changelog/@unreleased/pr-44.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Prefer inlining method references after whatever expression they follow.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/44

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -296,7 +296,7 @@ public final class Level extends Doc {
         //    In this case, recurse rather than go into computeBreaks.
         if (lastLevel.breakabilityIfLastLevel == LastLevelBreakability.CHECK_INNER) {
             // Try to fit the entire inner prefix if it's that kind of level.
-            Optional<Optional<State>> couldBreakRecursively = BreakBehaviours.caseOf(lastLevel.breakBehaviour)
+            return BreakBehaviours.caseOf(lastLevel.breakBehaviour)
                     .preferBreakingLastInnerLevel(keepIndentWhenInlined -> {
                         State state2 = state1;
                         if (keepIndentWhenInlined) {
@@ -305,10 +305,7 @@ public final class Level extends Doc {
                         return lastLevel.tryBreakLastLevel(commentsHelper, maxWidth, state2, true);
                     })
                     // We don't know how to fit the inner level on the same line, so bail out.
-                    .otherwiseEmpty();
-            if (couldBreakRecursively.isPresent()) {
-                return couldBreakRecursively.get();
-            }
+                    .otherwise_(Optional.empty());
 
         } else if (lastLevel.breakabilityIfLastLevel == LastLevelBreakability.ONLY_IF_FIRST_LEVEL_FITS) {
             // Otherwise, we may be able to check if the first inner level of the lastLevel fits.

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -899,8 +899,15 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     @Override
     public Void visitMemberReference(MemberReferenceTree node, Void unused) {
         sync(node);
-        builder.open(plusFour);
+        builder.open(OpenOp.builder()
+                .plusIndent(plusFour)
+                .debugName("methodReference")
+                // Would like to use CHECK_INNER but we'd have to check in the _first_ level rather than the last
+                // level, which the current logic can't do yet.
+                .breakabilityIfLastLevel(LastLevelBreakability.BREAK_HERE)
+                .build());
         scan(node.getQualifierExpression(), null);
+        builder.open(ZERO);
         builder.breakOp();
         builder.op("::");
         addTypeArguments(node.getTypeArguments(), plusFour);
@@ -914,6 +921,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             default:
                 throw new AssertionError(node.getMode());
         }
+        builder.close();
         builder.close();
         return null;
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-gcv-1.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-gcv-1.output
@@ -1,25 +1,18 @@
 class PalantirGcv1 {
     public static void main(String[] args) {
-        constraintsProperty.addAll(project.provider(
-                Suppliers.memoize(() -> {
-                            log.debug(
-                                    "Computing publish constraints for {} by resolving {}",
-                                    configuration.get(),
-                                    configurationForFiltering.get());
-                            Set<ModuleIdentifier> modulesToInclude =
-                                    configurationForFiltering
-                                            .get()
-                                            .getIncoming()
-                                            .getResolutionResult()
-                                            .getAllComponents()
-                                            .stream()
-                                            .map(ResolvedComponentResult::getModuleVersion)
-                                            .filter(Objects::nonNull)
-                                            .map(ModuleVersionIdentifier::getModule)
-                                            .collect(Collectors.toSet());
-                            return Collections2.filter(publishConstraints, constraint ->
-                                    modulesToInclude.contains(constraint.getModule()));
-                        })
-                        ::get));
+        constraintsProperty.addAll(project.provider(Suppliers.memoize(() -> {
+            log.debug(
+                    "Computing publish constraints for {} by resolving {}",
+                    configuration.get(),
+                    configurationForFiltering.get());
+            Set<ModuleIdentifier> modulesToInclude =
+                    configurationForFiltering.get().getIncoming().getResolutionResult().getAllComponents().stream()
+                            .map(ResolvedComponentResult::getModuleVersion)
+                            .filter(Objects::nonNull)
+                            .map(ModuleVersionIdentifier::getModule)
+                            .collect(Collectors.toSet());
+            return Collections2.filter(
+                    publishConstraints, constraint -> modulesToInclude.contains(constraint.getModule()));
+        })::get));
     }
 }


### PR DESCRIPTION
## Before this PR

The formatter would produce code that fails checkstyle, by indenting a block before a method reference too much.

## After this PR
==COMMIT_MSG==
Prefer inlining method references after whatever expression they follow.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

