### PR TITLE
Fix: NON-NLS comments move before `+` in string concatenations

### DIFF
--- a/changelog/@unreleased/pr-45.v2.yml
+++ b/changelog/@unreleased/pr-45.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: NON-NLS comments are moved behind `+` tokens in string concatenations.
+    This is a heuristic that doesn't look at what the thing before the `+` is, so
+    it might produce confusing results.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/45

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -547,8 +547,8 @@ public final class OpsBuilder {
                     boolean nonNlsCommentsAfterPlus = token.getToksAfter().stream()
                                     .anyMatch(OpsBuilder::isNonNlsComment)
                             && token.getTok().getText().equals("+")
-                            && i > 0
-                            && ops.get(i - 1) instanceof Break;
+                            && k > 0
+                            && ops.get(k - 1) instanceof Break;
 
                     int tokAfterPos = nonNlsCommentsAfterPlus ? k - 1 : k + 1;
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -544,11 +544,11 @@ public final class OpsBuilder {
 
                     // Reordering of NON-NLS comments that might follow a `+` in a chain of string concatenations, in
                     // order to move the comments before the Break that precedes the `+` token.
-                    Op previousOp = ops.get(i - 1);
                     boolean nonNlsCommentsAfterPlus = token.getToksAfter().stream()
                                     .anyMatch(OpsBuilder::isNonNlsComment)
                             && token.getTok().getText().equals("+")
-                            && previousOp instanceof Break;
+                            && i > 0
+                            && ops.get(i - 1) instanceof Break;
 
                     int tokAfterPos = nonNlsCommentsAfterPlus ? k - 1 : k + 1;
 

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/NON-NLS.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/NON-NLS.output
@@ -3,15 +3,11 @@ package test;
 class MultilineStringConstant {
 
     // NON-NLS comments are required for i18n, it's important they are kept with their strings.
-    private static final String MULTIPLE_LINE_NON_NLS = "field_0,"
-            + //$NON-NLS-1$
-            "field_1,"
-            + //$NON-NLS-1$
-            "field_2,"
-            + //$NON-NLS-1$
-            "field_3,"
-            + //$NON-NLS-1$
-            "field_4"; //$NON-NLS-1$
+    private static final String MULTIPLE_LINE_NON_NLS = "field_0," //$NON-NLS-1$
+            + "field_1," //$NON-NLS-1$
+            + "field_2," //$NON-NLS-1$
+            + "field_3," //$NON-NLS-1$
+            + "field_4"; //$NON-NLS-1$
 
     private static final String MULTIPLE_LINE_NO_COMMENT =
             "field_0," + "field_1," + "field_2," + "field_3," + "field_4";


### PR DESCRIPTION
## Before this PR

NON-NLS comments after `+` in chains of string concatenations are moved such that they don't follow the original string anymore.

## After this PR
==COMMIT_MSG==
NON-NLS comments are moved behind `+` tokens in string concatenations. This is a heuristic that doesn't look at what the thing before the `+` is, so it might produce confusing results.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

