### PR TITLE
Update sinceBuild, don't publish IDEA plugin unless clean tag

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -28,17 +28,14 @@ intellij {
 patchPluginXml {
     pluginDescription = "Formats source code using the palantir-java-format tool."
     version = project.version
-    sinceBuild = '173' // TODO: test against this version of IntelliJ to ensure no regressions
+    sinceBuild = '182' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
 }
 
 publishPlugin {
     token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
-    if (!versionDetails().isCleanTag) {
-        channels 'eap'
-    }
 }
-
+tasks.publishPlugin.onlyIf { versionDetails().isCleanTag }
 tasks.publish.dependsOn publishPlugin
 
 configurations {


### PR DESCRIPTION
## Before this PR

Keep getting compatibility error emails due to some deprecated methods being used in old versions of IDEA.

* `CodeStyleManager.fillIndent()`
* `CodeStyleManager.getIndent()`
* `CodeStyleManager.isLineToBeIndented()`
* `CodeStyleManager.zeroIndent()`

See e.g. https://plugins.jetbrains.com/plugin/13180-palantir-java-format/update/70978

These methods are still accessible from the old class, but have since been moved to a super class.

## After this PR
==COMMIT_MSG==
Bump minimum intellij build to 182 to get rid of spurious deprecation warnings on every publish.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

