### PR TITLE
Limit the max width of method chain dots

### DIFF
--- a/changelog/@unreleased/pr-70.v2.yml
+++ b/changelog/@unreleased/pr-70.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Limit how far dots may appear in long method chains to 80 chars.
+
+    Note that this doesn't currently apply to prefixes (such as `foo.bar().baz().stream()`) because prefixes are also used to group together fully qualified class names and it's a bit trickier to handle that case.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/70

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
@@ -69,7 +69,7 @@ public abstract class OpenOp implements Op {
 
     @Override
     public void add(DocBuilder builder) {
-        builder.open(plusIndent(), breakBehaviour(), breakabilityIfLastLevel(), debugName());
+        builder.open(this);
     }
 
     public static Builder builder() {

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
@@ -28,13 +28,19 @@ import org.immutables.value.Value.Default;
  */
 @Value.Immutable
 public abstract class OpenOp implements Op {
+    /** The extra indent inside this level. */
     public abstract Indent plusIndent();
 
+    /**
+     * When this level doesn't fit on one line, controls whether this level is to be broken (its breaks taken) or
+     * partially inlined onto the current line.
+     */
     @Default
     public BreakBehaviour breakBehaviour() {
         return BreakBehaviours.breakThisLevel();
     }
 
+    /** If it's the last level of its parent, when to inline this level rather than break the parent. */
     @Default
     public LastLevelBreakability breakabilityIfLastLevel() {
         return LastLevelBreakability.ABORT;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
@@ -18,6 +18,7 @@ import com.palantir.javaformat.doc.Doc;
 import com.palantir.javaformat.doc.DocBuilder;
 import com.palantir.javaformat.doc.Level;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Default;
 
@@ -47,6 +48,9 @@ public abstract class OpenOp implements Op {
     }
 
     public abstract Optional<String> debugName();
+
+    /** Custom max column limit that contents of this level <em>before the last break</em> may not exceed. */
+    public abstract OptionalInt columnLimitBeforeLastBreak();
 
     /**
      * Make an ordinary {@code OpenOp}.

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Break.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Break.java
@@ -96,17 +96,17 @@ public abstract class Break extends Doc implements Op {
     }
 
     @Override
-    float computeWidth() {
+    protected float computeWidth() {
         return isForced() ? Float.POSITIVE_INFINITY : (float) flat().length();
     }
 
     @Override
-    String computeFlat() {
+    protected String computeFlat() {
         return flat();
     }
 
     @Override
-    Range<Integer> computeRange() {
+    protected Range<Integer> computeRange() {
         return EMPTY_RANGE;
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Doc.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Doc.java
@@ -69,21 +69,21 @@ public abstract class Doc extends HasUniqueId {
      *
      * @return the width, or {@code Float.POSITIVE_INFINITY} if it must be broken
      */
-    abstract float computeWidth();
+    protected abstract float computeWidth();
 
     /**
      * Compute the {@code Doc}'s flat value. Not defined (and never called) if contains forced breaks.
      *
      * @return the flat value
      */
-    abstract String computeFlat();
+    protected abstract String computeFlat();
 
     /**
      * Compute the {@code Doc}'s {@link Range} of {@link Input.Token}s.
      *
      * @return the {@link Range}
      */
-    abstract Range<Integer> computeRange();
+    protected abstract Range<Integer> computeRange();
 
     /**
      * Make breaking decisions for a {@code Doc}.

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/DocBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/DocBuilder.java
@@ -17,20 +17,16 @@
 package com.palantir.javaformat.doc;
 
 import com.google.common.base.MoreObjects;
-import com.palantir.javaformat.BreakBehaviour;
-import com.palantir.javaformat.BreakBehaviours;
 import com.palantir.javaformat.Indent;
-import com.palantir.javaformat.LastLevelBreakability;
 import com.palantir.javaformat.Op;
+import com.palantir.javaformat.OpenOp;
 import com.palantir.javaformat.OpsBuilder;
 import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Optional;
 
 /** A {@code DocBuilder} converts a sequence of {@link Op}s into a {@link Doc}. */
 public final class DocBuilder {
-    private final Level base = Level.make(
-            Indent.Const.ZERO, BreakBehaviours.breakThisLevel(), LastLevelBreakability.ABORT, Optional.of("root"));
+    private final Level base = Level.make(OpenOp.builder().plusIndent(Indent.Const.ZERO).debugName("root").build());
     private final ArrayDeque<Level> stack = new ArrayDeque<>();
 
     /**
@@ -68,20 +64,9 @@ public final class DocBuilder {
         return this;
     }
 
-    /**
-     * Open a new {@link Level}.
-     *
-     * @param plusIndent the extra indent for the {@link Level}
-     * @param breakBehaviour how to decide whether to break this level or not
-     * @param breakabilityIfLastLevel if last level, when to break this rather than parent
-     * @param debugName
-     */
-    public void open(
-            Indent plusIndent,
-            BreakBehaviour breakBehaviour,
-            LastLevelBreakability breakabilityIfLastLevel,
-            Optional<String> debugName) {
-        Level level = Level.make(plusIndent, breakBehaviour, breakabilityIfLastLevel, debugName);
+    /** Open a new {@link Level}. */
+    public void open(OpenOp openOp) {
+        Level level = Level.make(openOp);
         stack.addLast(level);
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -361,7 +361,7 @@ public final class Level extends Doc {
             CommentsHelper commentsHelper, int maxWidth, State state, Optional<Break> optBreakDoc, List<Doc> split) {
         float breakWidth = optBreakDoc.isPresent() ? optBreakDoc.get().getWidth() : 0.0F;
         float splitWidth = getWidth(split);
-        boolean shouldBreak = (optBreakDoc.isPresent() && optBreakDoc.get().getFillMode() == FillMode.UNIFIED)
+        boolean shouldBreak = (optBreakDoc.isPresent() && optBreakDoc.get().fillMode() == FillMode.UNIFIED)
                 || state.mustBreak()
                 || state.column() + breakWidth + splitWidth > maxWidth;
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -73,7 +73,7 @@ public final class Level extends Doc {
     }
 
     @Override
-    float computeWidth() {
+    protected float computeWidth() {
         float thisWidth = 0.0F;
         for (Doc doc : docs) {
             thisWidth += doc.getWidth();
@@ -82,7 +82,7 @@ public final class Level extends Doc {
     }
 
     @Override
-    String computeFlat() {
+    protected String computeFlat() {
         StringBuilder builder = new StringBuilder();
         for (Doc doc : docs) {
             builder.append(doc.getFlat());
@@ -91,7 +91,7 @@ public final class Level extends Doc {
     }
 
     @Override
-    Range<Integer> computeRange() {
+    protected Range<Integer> computeRange() {
         Range<Integer> docRange = EMPTY_RANGE;
         for (Doc doc : docs) {
             docRange = union(docRange, doc.range());

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -28,6 +28,7 @@ import com.palantir.javaformat.BreakBehaviours;
 import com.palantir.javaformat.CommentsHelper;
 import com.palantir.javaformat.Indent;
 import com.palantir.javaformat.LastLevelBreakability;
+import com.palantir.javaformat.OpenOp;
 import com.palantir.javaformat.Output;
 import com.palantir.javaformat.doc.StartsWithBreakVisitor.Result;
 import java.util.ArrayList;
@@ -47,41 +48,19 @@ public final class Level extends Doc {
 
     private static final Collector<Level, ?, Optional<Level>> GET_LAST_COLLECTOR = Collectors.reducing((u, v) -> v);
 
-    private final Indent plusIndent; // The extra indent following breaks.
-    private final BreakBehaviour breakBehaviour; // Where to break when we can't fit on one line.
-    private final LastLevelBreakability breakabilityIfLastLevel;
-    // If last level, when to break this rather than parent.
-    private final Optional<String> debugName;
     private final List<Doc> docs = new ArrayList<>(); // The elements of the level.
     private final ImmutableSupplier<SplitsBreaks> memoizedSplitsBreaks =
             Suppliers.memoize(() -> splitByBreaks(docs))::get;
+    /** The immutable characteristics of this level determined before the level contents are available. */
+    private final OpenOp openOp;
 
-    private Level(
-            Indent plusIndent,
-            BreakBehaviour breakBehaviour,
-            LastLevelBreakability breakabilityIfLastLevel,
-            Optional<String> debugName) {
-        this.plusIndent = plusIndent;
-        this.breakBehaviour = breakBehaviour;
-        this.breakabilityIfLastLevel = breakabilityIfLastLevel;
-        this.debugName = debugName;
+    private Level(OpenOp openOp) {
+        this.openOp = openOp;
     }
 
-    /**
-     * Factory method for {@code Level}s.
-     *
-     * @param plusIndent the extra indent inside the {@code Level}
-     * @param breakBehaviour whether to attempt breaking only the last inner level first, instead of this level
-     * @param breakabilityIfLastLevel if last level, when to break this rather than parent
-     * @param debugName
-     * @return the new {@code Level}
-     */
-    static Level make(
-            Indent plusIndent,
-            BreakBehaviour breakBehaviour,
-            LastLevelBreakability breakabilityIfLastLevel,
-            Optional<String> debugName) {
-        return new Level(plusIndent, breakBehaviour, breakabilityIfLastLevel, debugName);
+    /** Factory method for {@code Level}s. */
+    static Level make(OpenOp openOp) {
+        return new Level(openOp);
     }
 
     /**
@@ -128,7 +107,7 @@ public final class Level extends Doc {
                     .withLevelState(this, ImmutableLevelState.of(true));
         }
 
-        State newState = breakBehaviour.match(new BreakImpl(commentsHelper, maxWidth, state));
+        State newState = getBreakBehaviour().match(new BreakImpl(commentsHelper, maxWidth, state));
 
         return state.updateAfterLevel(newState);
     }
@@ -145,7 +124,7 @@ public final class Level extends Doc {
         }
 
         private State breakNormally(State state) {
-            return computeBroken(commentsHelper, maxWidth, state.withIndentIncrementedBy(plusIndent));
+            return computeBroken(commentsHelper, maxWidth, state.withIndentIncrementedBy(getPlusIndent()));
         }
 
         @Override
@@ -227,7 +206,7 @@ public final class Level extends Doc {
         if (prefixFits) {
             State newState = state.withNoIndent();
             if (keepIndent) {
-                newState = newState.withIndentIncrementedBy(plusIndent);
+                newState = newState.withIndentIncrementedBy(getPlusIndent());
             }
             return Optional.of(
                     tryToLayOutLevelOnOneLine(commentsHelper, maxWidth, newState, memoizedSplitsBreaks.get()));
@@ -242,7 +221,7 @@ public final class Level extends Doc {
         }
         Level lastLevel = ((Level) getLast(docs));
         // Only split levels that have declared they want to be split in this way.
-        if (lastLevel.breakabilityIfLastLevel == LastLevelBreakability.ABORT) {
+        if (lastLevel.getBreakabilityIfLastLevel() == LastLevelBreakability.ABORT) {
             return Optional.empty();
         }
         // See if we can fill in everything but the lastDoc.
@@ -269,9 +248,9 @@ public final class Level extends Doc {
         //  * the lastLevel wants to be split, i.e. has Breakability.BREAK_HERE, then we continue
         //  * the lastLevel indicates we should check inside it for a potential split candidate.
         //    In this case, recurse rather than go into computeBreaks.
-        if (lastLevel.breakabilityIfLastLevel == LastLevelBreakability.CHECK_INNER) {
+        if (lastLevel.getBreakabilityIfLastLevel() == LastLevelBreakability.CHECK_INNER) {
             // Try to fit the entire inner prefix if it's that kind of level.
-            return BreakBehaviours.caseOf(lastLevel.breakBehaviour)
+            return BreakBehaviours.caseOf(lastLevel.getBreakBehaviour())
                     .preferBreakingLastInnerLevel(keepIndentWhenInlined -> {
                         State state2 = state1;
                         if (keepIndentWhenInlined) {
@@ -282,7 +261,7 @@ public final class Level extends Doc {
                     // We don't know how to fit the inner level on the same line, so bail out.
                     .otherwise_(Optional.empty());
 
-        } else if (lastLevel.breakabilityIfLastLevel == LastLevelBreakability.ONLY_IF_FIRST_LEVEL_FITS) {
+        } else if (lastLevel.getBreakabilityIfLastLevel() == LastLevelBreakability.ONLY_IF_FIRST_LEVEL_FITS) {
             // Otherwise, we may be able to check if the first inner level of the lastLevel fits.
             // This is safe because we assume (and check) that a newline comes after it, even though
             // it might be nested somewhere deep in the 2nd level.
@@ -429,11 +408,11 @@ public final class Level extends Doc {
     }
 
     Indent getPlusIndent() {
-        return plusIndent;
+        return openOp.plusIndent();
     }
 
     BreakBehaviour getBreakBehaviour() {
-        return breakBehaviour;
+        return openOp.breakBehaviour();
     }
 
     List<Doc> getDocs() {
@@ -441,11 +420,11 @@ public final class Level extends Doc {
     }
 
     LastLevelBreakability getBreakabilityIfLastLevel() {
-        return breakabilityIfLastLevel;
+        return openOp.breakabilityIfLastLevel();
     }
 
     public Optional<String> getDebugName() {
-        return debugName;
+        return openOp.debugName();
     }
 
     /** An indented representation of this level and all nested levels inside it. */
@@ -474,10 +453,10 @@ public final class Level extends Doc {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("debugName", debugName)
-                .add("plusIndent", plusIndent)
-                .add("breakBehaviour", breakBehaviour)
-                .add("breakabilityIfLastLevel", breakabilityIfLastLevel)
+                .add("debugName", getDebugName())
+                .add("plusIndent", getPlusIndent())
+                .add("breakBehaviour", getBreakBehaviour())
+                .add("breakabilityIfLastLevel", getBreakabilityIfLastLevel())
                 .add("docs", docs)
                 .toString();
     }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -102,14 +102,10 @@ public final class Level extends Doc {
 
     @Override
     public State computeBreaks(CommentsHelper commentsHelper, int maxWidth, State state) {
-        Optional<State> oneLine = tryToFitOnOneLine(maxWidth, state);
-        if (oneLine.isPresent()) {
-            return oneLine.get();
-        }
-
-        State newState = getBreakBehaviour().match(new BreakImpl(commentsHelper, maxWidth, state));
-
-        return state.updateAfterLevel(newState);
+        return tryToFitOnOneLine(maxWidth, state).orElseGet(() -> {
+            State newState = getBreakBehaviour().match(new BreakImpl(commentsHelper, maxWidth, state));
+            return state.updateAfterLevel(newState);
+        });
     }
 
     /**

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/LevelDelimitedFlatValueDocVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/LevelDelimitedFlatValueDocVisitor.java
@@ -48,7 +48,7 @@ public final class LevelDelimitedFlatValueDocVisitor implements DocVisitor<Strin
     public String visitBreak(Break doc) {
         StringBuilder sb =
                 new StringBuilder().append("⏎").append(doc.getFlat().isEmpty() ? "" : "(" + doc.getFlat() + ")");
-        if (!doc.getPlusIndent().equals(Indent.Const.ZERO)) {
+        if (!doc.plusIndent().equals(Indent.Const.ZERO)) {
             sb.append(" +" + doc.evalPlusIndent(state));
         }
         return sb.toString();

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Space.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Space.java
@@ -45,17 +45,17 @@ public final class Space extends Doc implements Op {
     }
 
     @Override
-    float computeWidth() {
+    protected float computeWidth() {
         return 1.0F;
     }
 
     @Override
-    String computeFlat() {
+    protected String computeFlat() {
         return " ";
     }
 
     @Override
-    Range<Integer> computeRange() {
+    protected Range<Integer> computeRange() {
         return Doc.EMPTY_RANGE;
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Tok.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Tok.java
@@ -51,7 +51,7 @@ public final class Tok extends Doc implements Op {
     }
 
     @Override
-    float computeWidth() {
+    protected float computeWidth() {
         int idx = Newlines.firstBreak(tok.getOriginalText());
         // only count the first line of multi-line block comments
         if (tok.isComment()) {
@@ -68,7 +68,7 @@ public final class Tok extends Doc implements Op {
     }
 
     @Override
-    String computeFlat() {
+    protected String computeFlat() {
         // TODO(cushon): commentsHelper.rewrite doesn't get called for spans that fit in a single
         // line. That's fine for multi-line comment reflowing, but problematic for adding missing
         // spaces in line comments.
@@ -79,7 +79,7 @@ public final class Tok extends Doc implements Op {
     }
 
     @Override
-    Range<Integer> computeRange() {
+    protected Range<Integer> computeRange() {
         return Range.singleton(tok.getIndex()).canonical(INTEGERS);
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Token.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Token.java
@@ -105,17 +105,17 @@ public final class Token extends Doc implements Op {
     }
 
     @Override
-    float computeWidth() {
+    protected float computeWidth() {
         return token.getTok().length();
     }
 
     @Override
-    String computeFlat() {
+    protected String computeFlat() {
         return token.getTok().getOriginalText();
     }
 
     @Override
-    Range<Integer> computeRange() {
+    protected Range<Integer> computeRange() {
         return Range.singleton(token.getTok().getIndex()).canonical(INTEGERS);
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -157,6 +157,13 @@ import org.openjdk.tools.javac.tree.TreeScanner;
 /** An AST visitor that builds a stream of {@link Op}s to format from the given {@link CompilationUnitTree}. */
 public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
+    /**
+     * Maximum column at which the last dot of a method chain may start. This exists in particular to improve
+     * readability of builder chains, but also in general to prevent hard to spot extra actions at the end of a method
+     * chain.
+     */
+    private static final int METHOD_CHAIN_COLUMN_LIMIT = 80;
+
     /** Direction for Annotations (usually VERTICAL). */
     enum Direction {
         VERTICAL,
@@ -2693,6 +2700,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                     .plusIndent(plusFour)
                     .breakBehaviour(BreakBehaviours.preferBreakingLastInnerLevel(false))
                     .breakabilityIfLastLevel(LastLevelBreakability.CHECK_INNER)
+                    .columnLimitBeforeLastBreak(METHOD_CHAIN_COLUMN_LIMIT)
                     .build());
         }
         // don't break after the first element if it is every small, unless the
@@ -2780,6 +2788,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                                 ? BreakBehaviours.preferBreakingLastInnerLevel(true)
                                 : BreakBehaviours.breakThisLevel())
                 .breakabilityIfLastLevel(LastLevelBreakability.ONLY_IF_FIRST_LEVEL_FITS)
+                .columnLimitBeforeLastBreak(METHOD_CHAIN_COLUMN_LIMIT)
                 .build());
 
         for (int times = 0; times < prefixes.size(); times++) {

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21954779.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21954779.output
@@ -29,6 +29,7 @@ class B21954779 {
         bind(new Key<ServiceMethodRunner<SyncReferenceNumberRequest, SyncReferenceNumberResponse>>() {});
 
         // this isn't a feature; we'd prefer to keep `new Key...` as one unit
-        bind(new Key<ServiceMethodRunner<SyncReferenceNumberRequest, SyncReferenceNumberResponses>>() {}).then();
+        bind(new Key<ServiceMethodRunner<SyncReferenceNumberRequest, SyncReferenceNumberResponses>>() {})
+                .then();
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B32114928.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B32114928.output
@@ -1,6 +1,7 @@
 class B32114928 {
     {
         Class<T> tClass = (Class<T>)
-                verifyNotNull((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+                verifyNotNull((ParameterizedType) getClass().getGenericSuperclass())
+                        .getActualTypeArguments()[0];
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B35644813.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B35644813.output
@@ -1,6 +1,8 @@
 class B35644813 {
     {
-        return foo____________.bar__________().baz____________().stream().map(Baz::getId).collect(toList());
+        return foo____________.bar__________().baz____________().stream()
+                .map(Baz::getId)
+                .collect(toList());
     }
 
     private static final ImmutableSet<String> SCANDINAVIA = ImmutableSet.of(

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I365.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I365.output
@@ -1,5 +1,7 @@
 class I365 {
     {
-        return foo____________.bar__________().baz____________().parallelStream().map(Baz::getId).collect(toList());
+        return foo____________.bar__________().baz____________().parallelStream()
+                .map(Baz::getId)
+                .collect(toList());
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
@@ -932,13 +932,16 @@ class M {
                 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
                         + 0 + 0 + 0 + 0 + 0 + 0);
         Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.ffffffffff(0);
-        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.fff(0).fff(0);
-        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.fff(0 + 0).fff(0);
+        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.fff(0)
+                .fff(0);
+        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.fff(0 + 0)
+                .fff(0);
         Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.fff(
                         0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
                                 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0)
                 .fff(0);
-        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.ffffffffff(0).fff(0);
+        Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.ffffffffff(0)
+                .fff(0);
         return this;
     }
 
@@ -951,9 +954,14 @@ class M {
         ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0);
         ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
                 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0);
-        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0).f(0);
-        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0).fff(0).fff(0).f(0);
-        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0).ffffffffff(0);
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0)
+                .f(0);
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0)
+                .fff(0)
+                .fff(0)
+                .f(0);
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(0)
+                .ffffffffff(0);
         return this;
     }
 


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Limit how far dots may appear in long method chains to 80 chars.

Note that this doesn't currently apply to prefixes (such as `foo.bar().baz().stream()`) because prefixes are also used to group together fully qualified class names and it's a bit trickier to handle that case.

Fixes #69.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

