### PR TITLE
Fix: Limit dotted chains for expressions starting with complex expression

### DIFF
--- a/changelog/@unreleased/pr-71.v2.yml
+++ b/changelog/@unreleased/pr-71.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Limit dotted chains for expressions starting with constructor.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/71

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -2600,8 +2600,13 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 scan(getArrayBase(node), null);
                 token(".");
             } else {
-                builder.open(
-                        plusFour, BreakBehaviours.preferBreakingLastInnerLevel(true), LastLevelBreakability.BREAK_HERE);
+                builder.open(OpenOp.builder()
+                        .debugName("visitDot")
+                        .plusIndent(plusFour)
+                        .breakBehaviour(BreakBehaviours.preferBreakingLastInnerLevel(true))
+                        .breakabilityIfLastLevel(LastLevelBreakability.BREAK_HERE)
+                        .columnLimitBeforeLastBreak(METHOD_CHAIN_COLUMN_LIMIT)
+                        .build());
                 scan(getArrayBase(node), null);
                 builder.breakOp();
                 needDot = true;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21031147.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21031147.output
@@ -1,5 +1,8 @@
 public class B21031147 {
     {
-        return new StringBuilder(maxLength).append(seq, 0, truncationLength).append(truncationIndicator).toString();
+        return new StringBuilder(maxLength)
+                .append(seq, 0, truncationLength)
+                .append(truncationIndicator)
+                .toString();
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22488373.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22488373.output
@@ -2,6 +2,8 @@ class B22488373 {
     {
         if (enumBindingKeys.contains(bindingKey)
                 && (bindingKey.key().type().getKind().equals(DECLARED)
-                        && !((DeclaredType) bindingKey.key().type()).getTypeArguments().isEmpty())) {}
+                        && !((DeclaredType) bindingKey.key().type())
+                                .getTypeArguments()
+                                .isEmpty())) {}
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
@@ -868,7 +868,11 @@ class M {
 
     void f(int... x) {
         M m = null;
-        ((m.identity().identity().identity().identity()).identity().identity().identity().identity())
+        ((m.identity().identity().identity().identity())
+                        .identity()
+                        .identity()
+                        .identity()
+                        .identity())
                 .identity()
                 .identity()
                 .identity()

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain.input
@@ -1,0 +1,6 @@
+class PalantirLongMethodChain {
+    private static void foo() {
+        new ObjectMapper().registerModule(new Jdk8Module()).readValue(file, TestCases.class).getClient();
+    }
+
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain.output
@@ -1,0 +1,8 @@
+class PalantirLongMethodChain {
+    private static void foo() {
+        new ObjectMapper()
+                .registerModule(new Jdk8Module())
+                .readValue(file, TestCases.class)
+                .getClient();
+    }
+}


### PR DESCRIPTION
## Before this PR

#70 didn't address all cases of method chains.

Specifically, cases where the dotted chain started with a constructor or a complex expression rather than a field / method call.

## After this PR
==COMMIT_MSG==
Limit dotted chains for expressions starting with a complex expression such as a parenthesized expression or a constructor. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

