### PR TITLE
Fix: reformat on commit uses PJF

### DIFF
--- a/changelog/@unreleased/pr-80.v2.yml
+++ b/changelog/@unreleased/pr-80.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '"Before commit -> Reformat code" now correctly uses the PJF formatter
+    if it is enabled, rather than the IntelliJ default formatter.'
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/80

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
@@ -65,10 +65,9 @@ class CodeStyleManagerDecorator extends CodeStyleManager implements FormattingMo
     }
 
     @Override
-    public final PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
+    public PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
             throws IncorrectOperationException {
-        // Preserve the fallback defined in CodeStyleManagerImpl
-        return reformatRange(element, startOffset, endOffset, false);
+        return delegate.reformatRange(element, startOffset, endOffset);
     }
 
     @Override

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
@@ -65,9 +65,10 @@ class CodeStyleManagerDecorator extends CodeStyleManager implements FormattingMo
     }
 
     @Override
-    public PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
+    public final PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
             throws IncorrectOperationException {
-        return delegate.reformatRange(element, startOffset, endOffset);
+        // Preserve the fallback defined in CodeStyleManagerImpl
+        return reformatRange(element, startOffset, endOffset, false);
     }
 
     @Override

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
@@ -39,6 +39,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.ChangedRangesInfo;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.impl.CheckUtil;
 import com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl;
@@ -133,12 +134,25 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
     }
 
     @Override
+    public void reformatTextWithContext(PsiFile psiFile, ChangedRangesInfo changedRangesInfo)
+            throws IncorrectOperationException {
+        reformatTextWithContext(psiFile, changedRangesInfo.allChangedRanges);
+    }
+
+    @Override
     public void reformatTextWithContext(PsiFile file, Collection<TextRange> ranges) {
         if (overrideFormatterForFile(file)) {
             formatInternal(file, ranges);
         } else {
             super.reformatTextWithContext(file, ranges);
         }
+    }
+
+    @Override
+    public PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
+            throws IncorrectOperationException {
+        // Preserve the fallback defined in CodeStyleManagerImpl
+        return reformatRange(element, startOffset, endOffset, false);
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
Ticking "Before commit -> Reformat code" when committing from within IntelliJ would enter a code path that skips the PJF formatter and uses the built-in IntelliJ one instead.

This code path would call `CodeStyleManager.reformatTextWithContext(PsiFile, ChangedRangesInfo)` which the `CodeStyleManagerDecorator` would just delegate to the default implementation.
Currently, PalantirCodeStyleManager only overrides one of the two "reformatTextWithContext" methods.

## After this PR
==COMMIT_MSG==
"Before commit -> Reformat code" now correctly uses the PJF formatter if it is enabled, rather than the IntelliJ default formatter.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

