### PR TITLE
Fix: don't inline level prefix if breaks occurred inside

### DIFF
--- a/changelog/@unreleased/pr-85.v2.yml
+++ b/changelog/@unreleased/pr-85.v2.yml
@@ -1,0 +1,11 @@
+type: fix
+fix:
+  description: "When inlining a level's leading docs, check that no breaks were introduced
+    more robustly.\n\nWe already did some validation that the leading docs \n (1)
+    don't contain forced breaks, and\n (2) can fit onto the current line\nHowever
+    with the new logic added in #71, inner levels might decide to break even when
+    the above two conditions are satisfied.\n\nWe guard against this by checking whether
+    the state after the inlining of leading docs has recorded new lines, which would
+    be caused by an inner break being taken."
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/85

--- a/changelog/@unreleased/pr-85.v2.yml
+++ b/changelog/@unreleased/pr-85.v2.yml
@@ -1,11 +1,6 @@
 type: fix
 fix:
   description: "When inlining a level's leading docs, check that no breaks were introduced
-    more robustly.\n\nWe already did some validation that the leading docs \n (1)
-    don't contain forced breaks, and\n (2) can fit onto the current line\nHowever
-    with the new logic added in #71, inner levels might decide to break even when
-    the above two conditions are satisfied.\n\nWe guard against this by checking whether
-    the state after the inlining of leading docs has recorded new lines, which would
-    be caused by an inner break being taken."
+    more robustly."
   links:
   - https://github.com/palantir/palantir-java-format/pull/85

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -295,8 +295,11 @@ public final class Level extends Doc {
         SplitsBreaks prefixSplitsBreaks = splitByBreaks(leadingDocs);
 
         State state1 = tryToLayOutLevelOnOneLine(commentsHelper, maxWidth, state, prefixSplitsBreaks, explorationNode);
-        Preconditions.checkState(
-                !state1.mustBreak(), "We messed up, it wants to break a bunch of splits that shouldn't be broken");
+        // If a break was still forced somehow even though we could fit the leadingWidth, then abort.
+        // This could happen if inner levels have set a `columnLimitBeforeLastBreak` or something like that.
+        if (state1.numLines() != state.numLines()) {
+            return Optional.empty();
+        }
 
         // Ok now how to handle the last level?
         // There are two options:

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-1.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-1.output
@@ -8,8 +8,10 @@ class PalantirConjureJavaRuntime1285_SslSocketFactories {
         KeyManager[] keyManagers = null;
         if (config.keyStorePath().isPresent()) {
             keyManagers = createKeyManagerFactory(
-                            config.keyStorePath().get(), config.keyStorePassword()
-                                    .get(), config.keyStoreType(), config.keyStoreKeyAlias())
+                            config.keyStorePath().get(),
+                            config.keyStorePassword().get(),
+                            config.keyStoreType(),
+                            config.keyStoreKeyAlias())
                     .getKeyManagers();
         }
 


### PR DESCRIPTION
## Before this PR

A level managed to get itself "inlined" as far as the formatter was concerned, even though a break was snuck in inside one of its inner levels.

## After this PR
==COMMIT_MSG==
When inlining a level's leading docs, check that no breaks were introduced more robustly.

We already did some validation that the leading docs 
 (1) don't contain forced breaks, and
 (2) can fit onto the current line
However with the new logic added in #71, inner levels might decide to break even when the above two conditions are satisfied.

We guard against this by checking whether the state after the inlining of leading docs has recorded new lines, which would be caused by an inner break being taken.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

