### PR TITLE
Don't allow inlined level to exceed columnLimitBeforeLastBreak

### DIFF
--- a/changelog/@unreleased/pr-101.v2.yml
+++ b/changelog/@unreleased/pr-101.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Partially inlined levels are now also limited such that the last dot
+    in method call chains can't exceed 80 characters.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/101

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/M.output
@@ -850,8 +850,9 @@ class M {
                                         Pair<Pair<Integer, Integer>, Pair<Integer, Integer>>,
                                         Pair<Pair<Integer, Integer>, Pair<Integer, Integer>>>>
                                 of(null);
-        Pair<Integer, Integer> pair1 = ImmutableList.<Pair<Integer, Integer>>of(null).get(0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
-                + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0);
+        Pair<Integer, Integer> pair1 = ImmutableList.<Pair<Integer, Integer>>of(null)
+                .get(0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
+                        + 0 + 0 + 0 + 0 + 0 + 0 + 0);
         Pair<Pair<Integer, Integer>, Pair<Integer, Integer>> pair2 =
                 ImmutableList.<Pair<Pair<Integer, Integer>, Pair<Integer, Integer>>>of(null)
                         .get(0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-reference.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-reference.output
@@ -3,8 +3,9 @@ class PalantirLongArrayInit {
         URL[] implementationUrls = implementationClassPath
                 .map(implementationUris -> {
                     log.debug("Using palantir-java-format implementation defined by URIs: {}", implementationUris);
-                    return implementationUris.stream().map(PalantirCodeStyleManager::toUrlUnchecked).toArray(URL[]
-                            ::new);
+                    return implementationUris.stream()
+                            .map(PalantirCodeStyleManager::toUrlUnchecked)
+                            .toArray(URL[]::new);
                 })
                 .orElse(null);
     }


### PR DESCRIPTION
## Before this PR

## After this PR
==COMMIT_MSG==
Partially inlined levels are also subject to the 'columnLimitBeforeLastBreak', that disallows the last dot in method call chains from exceeding 80 characters.

Fixes #100
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

