### PR TITLE
Don't inline annotations

### DIFF
--- a/changelog/@unreleased/pr-102.v2.yml
+++ b/changelog/@unreleased/pr-102.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Never put field annotations on the same line as the field declaration.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/102

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -949,7 +949,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     @Override
     public Void visitVariable(VariableTree node, Void unused) {
         sync(node);
-        visitVariables(ImmutableList.of(node), DeclarationKind.NONE, fieldAnnotationDirection(node.getModifiers()));
+        visitVariables(ImmutableList.of(node), DeclarationKind.NONE, inlineAnnotationDirection(node.getModifiers()));
         return null;
     }
 
@@ -1863,7 +1863,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                     VariableTree variableTree = (VariableTree) resource;
                     declareOne(
                             DeclarationKind.PARAMETER,
-                            fieldAnnotationDirection(variableTree.getModifiers()),
+                            inlineAnnotationDirection(variableTree.getModifiers()),
                             Optional.of(variableTree.getModifiers()),
                             variableTree.getType(),
                             /* name= */ variableTree.getName(),
@@ -3585,10 +3585,10 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /**
-     * Should a field with a set of modifiers be declared with horizontal annotations? This is currently true if all
-     * annotations are marker annotations.
+     * Should a declaration with a set of modifiers be declared with horizontal annotations? This is currently true if
+     * all annotations are marker annotations.
      */
-    private Direction fieldAnnotationDirection(ModifiersTree modifiers) {
+    private Direction inlineAnnotationDirection(ModifiersTree modifiers) {
         for (AnnotationTree annotation : modifiers.getAnnotations()) {
             if (!annotation.getArguments().isEmpty()) {
                 return Direction.VERTICAL;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -3584,16 +3584,10 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /**
-     * Should a field with a set of modifiers be declared with horizontal annotations? This is currently true if all
-     * annotations are marker annotations.
+     * Should a field with a set of modifiers be declared with horizontal annotations? This is currently never true.
      */
     private Direction fieldAnnotationDirection(ModifiersTree modifiers) {
-        for (AnnotationTree annotation : modifiers.getAnnotations()) {
-            if (!annotation.getArguments().isEmpty()) {
-                return Direction.VERTICAL;
-            }
-        }
-        return Direction.HORIZONTAL;
+        return Direction.VERTICAL;
     }
 
     /**

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -3497,7 +3497,8 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                     visitVariables(
                             variableFragments(it, bodyDeclaration),
                             DeclarationKind.FIELD,
-                            fieldAnnotationDirection(((VariableTree) bodyDeclaration).getModifiers()));
+                            // We always want field annotations to be vertical
+                            Direction.VERTICAL);
                 } else {
                     scan(bodyDeclaration, null);
                 }
@@ -3584,10 +3585,16 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /**
-     * Should a field with a set of modifiers be declared with horizontal annotations? This is currently never true.
+     * Should a field with a set of modifiers be declared with horizontal annotations? This is currently true if all
+     * annotations are marker annotations.
      */
     private Direction fieldAnnotationDirection(ModifiersTree modifiers) {
-        return Direction.VERTICAL;
+        for (AnnotationTree annotation : modifiers.getAnnotations()) {
+            if (!annotation.getArguments().isEmpty()) {
+                return Direction.VERTICAL;
+            }
+        }
+        return Direction.HORIZONTAL;
     }
 
     /**

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -251,7 +251,8 @@ public final class FormatterTest {
                 + "import java.util.List;\n"
                 + "import javax.annotations.Nullable;\n\n"
                 + "public class ExampleTest {\n"
-                + "  @Nullable List<?> xs;\n"
+                + "  @Nullable\n"
+                + "  List<?> xs;\n"
                 + "}\n";
         assertThat(output).isEqualTo(expect);
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128588.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128588.output
@@ -23,11 +23,17 @@ class Test {
     @Baz
     void f() {}
 
-    @Foo @Bar @Baz static Object field;
+    @Foo
+    @Bar
+    @Baz
+    static Object field;
 
     static @Foo @Bar @Baz Object field;
 
-    @Foo @Bar @Baz Object field;
+    @Foo
+    @Bar
+    @Baz
+    Object field;
 
     @Foo(xs = 42)
     @Bar
@@ -87,7 +93,12 @@ class Test {
     @Deprecated
     Object var;
 
-    @Deprecated @Deprecated @Deprecated @Deprecated @Deprecated Object var;
+    @Deprecated
+    @Deprecated
+    @Deprecated
+    @Deprecated
+    @Deprecated
+    Object var;
 
     @Deprecated(x = 42)
     @Deprecated

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20577626.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20577626.output
@@ -1,7 +1,9 @@
 class B20577626 {
     private @Mock GsaConfigFlags mGsaConfig;
 
-    @Foo @Bar private @Mock GsaConfigFlags mGsaConfig;
+    @Foo
+    @Bar
+    private @Mock GsaConfigFlags mGsaConfig;
 
     @Foo
     abstract @Bar void m() {}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465477.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465477.output
@@ -1,10 +1,16 @@
 class B21465477 {
 
-    @Nullable private final String simpleFieldName;
-    @Nullable private final String shortFlagName;
+    @Nullable
+    private final String simpleFieldName;
+
+    @Nullable
+    private final String shortFlagName;
+
     private final String containerClassName;
     private final String type;
     private final String doc;
     private final DocLevel docLevel;
-    @Nullable private final String altName;
+
+    @Nullable
+    private final String altName;
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.output
@@ -1,14 +1,22 @@
 class B24702438 {
 
-    @Inject int x;
+    @Inject
+    int x;
 
-    @Inject int y;
+    @Inject
+    int y;
 
-    @Inject int z;
+    @Inject
+    int z;
 
-    @Inject int x;
-    @Inject int y;
-    @Inject int z;
+    @Inject
+    int x;
+
+    @Inject
+    int y;
+
+    @Inject
+    int z;
 
     // this is a comment
 

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1.output
@@ -16,9 +16,15 @@ class Test {
 
 class Test {
     final CreationMechanism creationMechanism;
-    @Nullable final String creationUserAgent;
+
+    @Nullable
+    final String creationUserAgent;
+
     final ClientId clientId;
-    @Nullable final String creationUserAgentXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
+
+    @Nullable
+    final String creationUserAgentXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
+
     final Token externalId;
 
     {
@@ -32,7 +38,8 @@ class Test {
 
 class Test {
 
-    @Nullable final String creationUserAgent;
+    @Nullable
+    final String creationUserAgent;
 
     {
         @Nullable final String creationUserAgent;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I13.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I13.output
@@ -1,6 +1,7 @@
 class I13 {
 
-    @Nullable public int f;
+    @Nullable
+    public int f;
 
     @Override
     public void m() {}


### PR DESCRIPTION
## Before this PR

Parameter-less annotations like `@Mock` on fields would be inlined horizontally.

## After this PR
==COMMIT_MSG==
Never put field annotations on the same line as the field declaration.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

