### PR TITLE
Fix string concats breaking weirdly

### DIFF
--- a/changelog/@unreleased/pr-104.v2.yml
+++ b/changelog/@unreleased/pr-104.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: No longer break string concats unless they are a method's only argument
+    on the line so far.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/104

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -1138,7 +1138,10 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         List<String> operators = new ArrayList<>();
         walkInfix(precedence(node), node, operands, operators);
         FillMode fillMode = hasOnlyShortItems(operands) ? INDEPENDENT : UNIFIED;
-        builder.open(plusFour, BreakBehaviours.breakThisLevel(), LastLevelBreakability.ACCEPT_INLINE_CHAIN);
+        builder.open(
+                plusFour,
+                BreakBehaviours.breakThisLevel(),
+                LastLevelBreakability.ACCEPT_INLINE_CHAIN_IF_SIMPLE_OTHERWISE_CHECK_INNER);
         scan(operands.get(0), null);
         int operatorsN = operators.size();
         for (int i = 0; i < operatorsN; i++) {

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.input
@@ -1,0 +1,16 @@
+/**
+ * https://github.com/palantir/conjure-java-runtime/blob/56e666aaf20f038dc11751c6a1f74998f8584a7d/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientFailoverTest.java#L146-L154
+ */
+class PalantirConjureJavaRuntime1285_Test2 {
+    public void foo() {
+        TestService bogusHostProxy = JaxRsClient.create(
+                TestService.class,
+                AGENT,
+                new HostMetricsRegistry(),
+                ClientConfiguration.builder()
+                        .from(createTestConfig("http://foo-bar-bogus-host.unresolvable:80", "http://localhost:"
+                                + failoverTestCase.server1.getPort()))
+                        .maxNumRetries(2)
+                        .build());
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.input
@@ -1,5 +1,5 @@
 /**
- * https://github.com/palantir/conjure-java-runtime/blob/56e666aaf20f038dc11751c6a1f74998f8584a7d/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientFailoverTest.java#L146-L154
+ * https://github.com/palantir/conjure-java-runtime/pull/1285/files#r356006884
  */
 class PalantirConjureJavaRuntime1285_Test2 {
     public void foo() {

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.output
@@ -1,0 +1,17 @@
+/**
+ * https://github.com/palantir/conjure-java-runtime/blob/56e666aaf20f038dc11751c6a1f74998f8584a7d/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientFailoverTest.java#L146-L154
+ */
+class PalantirConjureJavaRuntime1285_Test2 {
+    public void foo() {
+        TestService bogusHostProxy = JaxRsClient.create(
+                TestService.class,
+                AGENT,
+                new HostMetricsRegistry(),
+                ClientConfiguration.builder()
+                        .from(createTestConfig(
+                                "http://foo-bar-bogus-host.unresolvable:80",
+                                "http://localhost:" + failoverTestCase.server1.getPort()))
+                        .maxNumRetries(2)
+                        .build());
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-conjure-java-runtime-1285-2.output
@@ -1,6 +1,4 @@
-/**
- * https://github.com/palantir/conjure-java-runtime/blob/56e666aaf20f038dc11751c6a1f74998f8584a7d/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientFailoverTest.java#L146-L154
- */
+/** https://github.com/palantir/conjure-java-runtime/pull/1285/files#r356006884 */
 class PalantirConjureJavaRuntime1285_Test2 {
     public void foo() {
         TestService bogusHostProxy = JaxRsClient.create(


### PR DESCRIPTION
## Before this PR

String concatenations (or other binary operations) could be broken inside a method's multiple arguments that were otherwise inlined, and didn't look good.

See https://github.com/palantir/conjure-java-runtime/pull/1285/files#r356006884

## After this PR
==COMMIT_MSG==
No longer break string concats unless they are a method's only argument on the line so far.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

