### PR TITLE
Nested method chains also adhere to column limit

### DIFF
--- a/changelog/@unreleased/pr-123.v2.yml
+++ b/changelog/@unreleased/pr-123.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Nested method chains now also adhere to column limit.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/123

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -438,6 +438,11 @@ public final class OpsBuilder {
         add(Break.make(fillMode, flat, plusIndent, optionalTag));
     }
 
+    /** Emit a self-built {@link Break}. */
+    public void breakOp(Break breakOp) {
+        add(breakOp);
+    }
+
     private int lastPartialFormatBoundary = -1;
 
     /**

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Break.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Break.java
@@ -38,6 +38,9 @@ public abstract class Break extends Doc implements Op {
 
     public abstract Optional<BreakTag> optTag();
 
+    /** If this break is restricted by its parent {@link Level}'s {@link Level#getColumnLimitBeforeLastBreak()}. */
+    public abstract boolean hasColumnLimit();
+
     /**
      * Make a {@code Break}.
      *
@@ -47,7 +50,12 @@ public abstract class Break extends Doc implements Op {
      * @return the new {@code Break}
      */
     public static Break make(FillMode fillMode, String flat, Indent plusIndent) {
-        return builder().fillMode(fillMode).flat(flat).plusIndent(plusIndent).build();
+        return builder()
+                .fillMode(fillMode)
+                .flat(flat)
+                .plusIndent(plusIndent)
+                .hasColumnLimit(false)
+                .build();
     }
 
     /**
@@ -65,6 +73,7 @@ public abstract class Break extends Doc implements Op {
                 .flat(flat)
                 .plusIndent(plusIndent)
                 .optTag(optTag)
+                .hasColumnLimit(false)
                 .build();
     }
 
@@ -78,6 +87,7 @@ public abstract class Break extends Doc implements Op {
                 .fillMode(FillMode.FORCED)
                 .flat("")
                 .plusIndent(Indent.Const.ZERO)
+                .hasColumnLimit(false)
                 .build();
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -123,14 +123,14 @@ public final class Level extends Doc {
      *     maxWidth}
      */
     private Optional<Integer> tryToFitOnOneLine(int maxWidth, State state, Iterable<Doc> docs) {
-        float column = state.column();
-        float columnBeforeLastBreak = 0f; // Not activated by default
+        int column = state.column();
+        int columnBeforeLastBreak = 0; // Not activated by default
         for (Doc doc : docs) {
             if (doc instanceof Break && ((Break) doc).hasColumnLimit()) {
                 columnBeforeLastBreak = column;
             } else if (doc instanceof Level) {
                 // Levels might have nested levels that have a 'columnLimitBeforeLastBreak' set, so recurse.
-                State newState = state.withColumn((int) column);
+                State newState = state.withColumn(column);
                 Level innerLevel = (Level) doc;
                 Optional<Integer> newWidth = innerLevel.tryToFitOnOneLine(maxWidth, newState, innerLevel.getDocs());
                 if (!newWidth.isPresent()) {
@@ -148,9 +148,8 @@ public final class Level extends Doc {
         }
 
         // Check that the entirety of this level fits on the current line.
-        float thisWidth = getWidth(docs);
-        if (state.column() + thisWidth <= maxWidth) {
-            return Optional.of(state.column() + (int) thisWidth);
+        if (column <= maxWidth) {
+            return Optional.of(column);
         }
         return Optional.empty();
     }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -124,9 +124,9 @@ public final class Level extends Doc {
      */
     private Optional<Integer> tryToFitOnOneLine(int maxWidth, State state, Iterable<Doc> docs) {
         float column = state.column();
-        float columnBeforeLastBreak = column;
+        float columnBeforeLastBreak = 0f; // Not activated by default
         for (Doc doc : docs) {
-            if (doc instanceof Break) {
+            if (doc instanceof Break && ((Break) doc).hasColumnLimit()) {
                 columnBeforeLastBreak = column;
             } else if (doc instanceof Level) {
                 // Levels might have nested levels that have a 'columnLimitBeforeLastBreak' set, so recurse.
@@ -547,6 +547,10 @@ public final class Level extends Doc {
         return openOp;
     }
 
+    /**
+     * An optional, more restrictive column limit for inner breaks that are marked as {@link Break#hasColumnLimit()}. If
+     * the level is to be considered one-lineable, the last such break must not start at a column higher than this.
+     */
     public OptionalInt getColumnLimitBeforeLastBreak() {
         return openOp.columnLimitBeforeLastBreak();
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128760.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128760.output
@@ -11,8 +11,9 @@ class B20128760 {
                 .xxxxx();
 
         xxxxxxXxxx(xxx.xxxXxXxxxxxxx(new XxxxxxxxxXxxxxxxx.Xxxxxxx()
-                                .xxxxXxxxXxx(Xxxxx.xxxXxxxxXxxx(new XxxxXx(
-                                        xxxxxxxxx1.xxxXxxxXx().xxxXxxxx() + xxxxxxxxx2.xxxXxxxXx().xxxXxxxx())))
+                                .xxxxXxxxXxx(Xxxxx.xxxXxxxxXxxx(
+                                        new XxxxXx(xxxxxxxxx1.xxxXxxxXx().xxxXxxxx()
+                                                + xxxxxxxxx2.xxxXxxxXx().xxxXxxxx())))
                                 .xxxxx())
                         .xxxXxxxxxx())
                 .xxxxxxxxXxxxxxx();

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20701054.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20701054.output
@@ -14,14 +14,37 @@ class B20701054 {
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).build();
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).add(2).build();
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).add(2).add(3).build();
-        ImmutableList<String> x = ImmutableList.INSTANCE.add(1).add(2).add(3).add(4).build();
+        ImmutableList<String> x = ImmutableList.INSTANCE
+                .add(1)
+                .add(2)
+                .add(3)
+                .add(4)
+                .build();
 
         ImmutableList<String> x = ImmutableList.builder().add(1).build();
         ImmutableList<String> x = ImmutableList.builder().add(1).add(2).build();
         ImmutableList<String> x = ImmutableList.builder().add(1).add(2).add(3).build();
-        ImmutableList<String> x = ImmutableList.builder().add(1).add(2).add(3).add(4).build();
-        ImmutableList<String> x = ImmutableList.builder().add(1).add(2).add(3).add(4).add(5).build();
-        ImmutableList<String> x = ImmutableList.builder().add(1).add(2).add(3).add(4).add(5).add(6).build();
+        ImmutableList<String> x = ImmutableList.builder()
+                .add(1)
+                .add(2)
+                .add(3)
+                .add(4)
+                .build();
+        ImmutableList<String> x = ImmutableList.builder()
+                .add(1)
+                .add(2)
+                .add(3)
+                .add(4)
+                .add(5)
+                .build();
+        ImmutableList<String> x = ImmutableList.builder()
+                .add(1)
+                .add(2)
+                .add(3)
+                .add(4)
+                .add(5)
+                .add(6)
+                .build();
 
         ImmutableList<String> x = new ImmutableList.Builder<>()
                 .add(xxxxx)

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465217.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465217.output
@@ -4,7 +4,9 @@ class B21465217 {
                 BufferedOutputStream bout = new BufferedOutputStream(out2);
                 OutputStreamWriter writer = new OutputStreamWriter(bout, UTF_8___________________________)) {}
 
-        try (Writer sourceWriter = env.getFiler().createSourceFile(qualifiedNamezzzzzzzz).openWriter()) {
+        try (Writer sourceWriter = env.getFiler()
+                .createSourceFile(qualifiedNamezzzzzzzz)
+                .openWriter()) {
             sourceWriter.append(fileContents);
         }
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22610221.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22610221.output
@@ -1,6 +1,9 @@
 class B22610221 {
     {
-        for (Map.Entry<Key<Object>, Object> entry : FOO.bar().bazs().<Object>thing(someThing).entrySet()) {
+        for (Map.Entry<Key<Object>, Object> entry : FOO.bar()
+                .bazs()
+                .<Object>thing(someThing)
+                .entrySet()) {
             output.put(entry.getKey(), entry.getValue());
         }
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24909927.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24909927.output
@@ -122,8 +122,9 @@ class Xxx {
                                                         .xxxXxxx(XxxxXxxx.XXX)
                                                         .xxxxx())
                                                 .xxxxx())
-                                        .xxxXxxxxxxxxxXxxXxxxXxxxxxxxx(
-                                                XxxxxxxxxxXxxXxxxXxxxxxxxx.xxxXxxxxxx().xxxXxxxxxxxxxXxxxXx(42).xxxxx())
+                                        .xxxXxxxxxxxxxXxxXxxxXxxxxxxxx(XxxxxxxxxxXxxXxxxXxxxxxxxx.xxxXxxxxxx()
+                                                .xxxXxxxxxxxxxXxxxXx(42)
+                                                .xxxxx())
                                         .xxxxx())
                                 .xxxxx())
                         .xxxXxxxxxx(XxxxxxxXxxx.xxxXxxxxxx()

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B32114928.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B32114928.output
@@ -1,6 +1,7 @@
 class B32114928 {
     {
-        Class<T> tClass = (Class<T>) verifyNotNull((ParameterizedType) getClass().getGenericSuperclass())
-                .getActualTypeArguments()[0];
+        Class<T> tClass = (Class<T>)
+                verifyNotNull((ParameterizedType) getClass().getGenericSuperclass())
+                        .getActualTypeArguments()[0];
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-deeply-nested-calls.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-deeply-nested-calls.output
@@ -5,8 +5,9 @@ class PalantirDeeplyNestedCalls {
                     .foooos(ImmutableList.of(testFieldTwoV1, testFieldThreeV1))
                     .baaars(ImmutableList.of(MagicConfigV1.builder()
                             .baaars(ImmutableList.of(MagicConfigV1.builder()
-                                    .baaars(ImmutableList.of(
-                                            MagicConfigV1.builder().foooos(ImmutableList.of(testFieldFourV1)).build()))
+                                    .baaars(ImmutableList.of(MagicConfigV1.builder()
+                                            .foooos(ImmutableList.of(testFieldFourV1))
+                                            .build()))
                                     .build()))
                             .build()))
                     .build()))

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-lamda-cast.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-lamda-cast.output
@@ -10,7 +10,7 @@ public class Foo {
     }
 
     static String baz(Optional<String> optional) {
-        return optional.orElseGet(
-                (String) () -> bar(Optional.of("some thing that is very very very looooooong")).get());
+        return optional.orElseGet((String) () ->
+                bar(Optional.of("some thing that is very very very looooooong")).get());
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.input
@@ -1,0 +1,5 @@
+class PalantirLongMethodChainArg {
+    void foo() {
+        return cache.get(ImmutableRequest.builder().group(group).name(artifact).addRepositories("release-jar").build());
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.output
@@ -1,5 +1,9 @@
 class PalantirLongMethodChainArg {
     void foo() {
-        return cache.get(ImmutableRequest.builder().group(group).name(artifact).addRepositories("release-jar").build());
+        return cache.get(ImmutableRequest.builder()
+                .group(group)
+                .name(artifact)
+                .addRepositories("release-jar")
+                .build());
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-long-method-chain-arg.output
@@ -1,0 +1,5 @@
+class PalantirLongMethodChainArg {
+    void foo() {
+        return cache.get(ImmutableRequest.builder().group(group).name(artifact).addRepositories("release-jar").build());
+    }
+}


### PR DESCRIPTION
## Before this PR

#70 (and #71) failed to account for more complex expressions that contained a nested chain of method calls.

An example where it didn't do the right thing is [this test](https://github.com/palantir/palantir-java-format/compare/ds/long-method-chain-arg?expand=1#diff-e506d65564d6ba3a61926e5b6ac5cabf).

## After this PR
==COMMIT_MSG==
Nested method chains now also adhere to column limit.

Also, we've made the logic a bit more specific in terms of what are method chains.
We now only apply this restricted column limit to breaks that come before actual method calls, not field accesses or parts of a fully qualified class name.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

