### PR TITLE
Don't force long {@link} to stay on one line

### DIFF
--- a/changelog/@unreleased/pr-131.v2.yml
+++ b/changelog/@unreleased/pr-131.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Re-allow wrapping long inline tags like `{@link` from the 2nd whitespace
+    onwards.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/131

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
@@ -1207,6 +1207,30 @@ public final class JavadocFormattingTest {
         doFormatTest(input, expected);
     }
 
+    /**
+     * Test that a long {@code {@link #foo(many, arguments)}} while keeping {@code @link} and {@code foo(many} on the
+     * same line.
+     */
+    @Test
+    public void wrapsLongInlineTag_withoutBreakingFirstWhitespace() {
+        String[] input = {
+            "/**", //
+            " * This line is too long for the link to fit on a single line isn't it yes indeed too long {@link "
+                    + "#foo(bar, baz, there, are, just, so, many, arguments, arent, there, yep, indeed, yessir, yaya)}",
+            " */",
+            "class Test {}",
+        };
+        String[] expected = {
+            "/**", //
+            " * This line is too long for the link to fit on a single line isn't it yes indeed too long",
+            " * {@link #foo(bar, baz, there, are, just, so, many, arguments, arent, there, yep, indeed, yessir,",
+            " * yaya)}",
+            " */",
+            "class Test {}",
+        };
+        doFormatTest(input, expected);
+    }
+
     @Test
     void mergesClosingBraceWithFollowingTag() {
         String[] input = {

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/Unformatted2.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/Unformatted2.output
@@ -1,8 +1,8 @@
 package com.google.googlejavaformat;
 
 /**
- * Rewrite comments. This interface is implemented by
- * {@link com.google.googlejavaformat.java.JavaCommentsHelper JavaCommentsHelper}.
+ * Rewrite comments. This interface is implemented by {@link com.google.googlejavaformat.java.JavaCommentsHelper
+ * JavaCommentsHelper}.
  */
 public interface CommentsHelper {
     /**


### PR DESCRIPTION
## Before this PR

#125 made it so that `{@link <something>}` would stay on one line in javadocs, but it also made it so that long `{@link #method(arg1, arg2, arg3 ...)}` would also stay on one line, even if that exceeds the column limit.

## After this PR
==COMMIT_MSG==
Allow wrapping long inline tags like `{@link` from the 2nd whitespace onwards.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

