### PR TITLE
Fix column limit logic to work as expected with initializers

### DIFF
--- a/changelog/@unreleased/pr-138.v2.yml
+++ b/changelog/@unreleased/pr-138.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: 'Method chains in initializers may once again be laid onto a single
+    next line, if they are short enough. This fixes a regression from #123 (0.3.11)
+    where the column limit for method chains would prevent us from attempting to put
+    the initializer on the 2nd line first and see if that works.'
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/138

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -458,7 +458,7 @@ public final class Level extends Doc {
     }
 
     /** Lay out a Break-separated group of Docs in the current Level. */
-    private static State computeBreakAndSplit(
+    private State computeBreakAndSplit(
             CommentsHelper commentsHelper,
             int maxWidth,
             State state,
@@ -467,9 +467,12 @@ public final class Level extends Doc {
             Obs.ExplorationNode explorationNode) {
         float breakWidth = optBreakDoc.isPresent() ? optBreakDoc.get().getWidth() : 0.0F;
         float splitWidth = getWidth(split);
+
         boolean shouldBreak = (optBreakDoc.isPresent() && optBreakDoc.get().fillMode() == FillMode.UNIFIED)
                 || state.mustBreak()
-                || state.column() + breakWidth + splitWidth > maxWidth;
+                || Double.isInfinite(breakWidth)
+                || !tryToFitOnOneLine(maxWidth, state.withColumn(state.column() + (int) breakWidth), split)
+                        .isPresent();
 
         if (optBreakDoc.isPresent()) {
             state = optBreakDoc.get().computeBreaks(state, shouldBreak);

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20701054.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20701054.output
@@ -14,29 +14,16 @@ class B20701054 {
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).build();
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).add(2).build();
         ImmutableList<String> x = ImmutableList.INSTANCE.add(1).add(2).add(3).build();
-        ImmutableList<String> x = ImmutableList.INSTANCE
-                .add(1)
-                .add(2)
-                .add(3)
-                .add(4)
-                .build();
+        ImmutableList<String> x =
+                ImmutableList.INSTANCE.add(1).add(2).add(3).add(4).build();
 
         ImmutableList<String> x = ImmutableList.builder().add(1).build();
         ImmutableList<String> x = ImmutableList.builder().add(1).add(2).build();
         ImmutableList<String> x = ImmutableList.builder().add(1).add(2).add(3).build();
-        ImmutableList<String> x = ImmutableList.builder()
-                .add(1)
-                .add(2)
-                .add(3)
-                .add(4)
-                .build();
-        ImmutableList<String> x = ImmutableList.builder()
-                .add(1)
-                .add(2)
-                .add(3)
-                .add(4)
-                .add(5)
-                .build();
+        ImmutableList<String> x =
+                ImmutableList.builder().add(1).add(2).add(3).add(4).build();
+        ImmutableList<String> x =
+                ImmutableList.builder().add(1).add(2).add(3).add(4).add(5).build();
         ImmutableList<String> x = ImmutableList.builder()
                 .add(1)
                 .add(2)

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465217.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465217.output
@@ -4,9 +4,8 @@ class B21465217 {
                 BufferedOutputStream bout = new BufferedOutputStream(out2);
                 OutputStreamWriter writer = new OutputStreamWriter(bout, UTF_8___________________________)) {}
 
-        try (Writer sourceWriter = env.getFiler()
-                .createSourceFile(qualifiedNamezzzzzzzz)
-                .openWriter()) {
+        try (Writer sourceWriter =
+                env.getFiler().createSourceFile(qualifiedNamezzzzzzzz).openWriter()) {
             sourceWriter.append(fileContents);
         }
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22610221.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B22610221.output
@@ -1,9 +1,7 @@
 class B22610221 {
     {
-        for (Map.Entry<Key<Object>, Object> entry : FOO.bar()
-                .bazs()
-                .<Object>thing(someThing)
-                .entrySet()) {
+        for (Map.Entry<Key<Object>, Object> entry :
+                FOO.bar().bazs().<Object>thing(someThing).entrySet()) {
             output.put(entry.getKey(), entry.getValue());
         }
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.input
@@ -1,0 +1,7 @@
+class PalantirChainNextLine {
+    void foo() {
+        Iterator<Map.Entry<ThingId, DelegateOtherThing>> delegateIterator = delegates
+                .entrySet()
+                .iterator();
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.output
@@ -1,7 +1,6 @@
 class PalantirChainNextLine {
     void foo() {
-        Iterator<Map.Entry<ThingId, DelegateOtherThing>> delegateIterator = delegates
-                .entrySet()
-                .iterator();
+        Iterator<Map.Entry<ThingId, DelegateOtherThing>> delegateIterator =
+                delegates.entrySet().iterator();
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-chain-next-line.output
@@ -1,0 +1,7 @@
+class PalantirChainNextLine {
+    void foo() {
+        Iterator<Map.Entry<ThingId, DelegateOtherThing>> delegateIterator = delegates
+                .entrySet()
+                .iterator();
+    }
+}


### PR DESCRIPTION
## Before this PR

In a Level representing an assignment initializer (such as a variable or field declaration), there is an expectation that the initializer expression follows an optional break after the `=` or `:` (in the case of a for-each) sign.

We try to break that level first to see if just breaking once allows the rest of the initializer to fit on one line, and if so, we prefer that, instead of partially inlining the expression onto the `=` line, which may end up spanning more than 2 lines.

However, some shortcut logic for "does this chunk of code fit on the current line" was flawed in that it didn't take into account potential breaks due to column limits in method chains (which became a problem after #123). Therefore, at one point it decided it fits so we don't need to break after the `=`, but later down the line, it would end up breaking the code anyway because of the column limit.

## After this PR
==COMMIT_MSG==
Method chains in initializers may once again be laid onto a single next line, if they are short enough. This fixes a regression from #123 (0.3.11) where the column limit for method chains would prevent us from attempting to put the initializer on the 2nd line first and see if that works.
==COMMIT_MSG==

## Possible downsides?

Fewer builders are forcibly split onto multiple lines.
However, if we want to be more aggressive with pushing this behaviour for builders, we should do that differently, not as a side-effect of this bug.