### PR TITLE
wait longer for git diff

### DIFF
--- a/changelog/@unreleased/pr-144.v2.yml
+++ b/changelog/@unreleased/pr-144.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Make `formatDiff` task more resilient by waiting 30 seconds for git
+    diff output before giving up.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/144

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/FormatDiff.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/FormatDiff.java
@@ -134,7 +134,7 @@ final class FormatDiff {
         Process process =
                 new ProcessBuilder().command(args).directory(dir.toFile()).start();
 
-        Preconditions.checkState(process.waitFor(10, TimeUnit.SECONDS), "git diff took too long to terminate");
+        Preconditions.checkState(process.waitFor(30, TimeUnit.SECONDS), "git diff took too long to terminate");
         Preconditions.checkState(process.exitValue() == 0, "Expected return code of 0");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Before this PR

`git diff` on large repos fails to return in 10 seconds.

## After this PR
==COMMIT_MSG==
Wait 30 seconds for git diff output before giving up.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

