### PR TITLE
don't inline new Class without class body

### DIFF
--- a/changelog/@unreleased/pr-157.v2.yml
+++ b/changelog/@unreleased/pr-157.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Don't inline constructor calls without a custom body (i.e. if they
+    are not anonymous classes).
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/157

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -684,7 +684,11 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     public Void visitNewClass(NewClassTree node, Void unused) {
         sync(node);
         builder.open(
-                ZERO, BreakBehaviours.preferBreakingLastInnerLevel(true), LastLevelBreakability.ACCEPT_INLINE_CHAIN);
+                ZERO,
+                BreakBehaviours.preferBreakingLastInnerLevel(true),
+                node.getClassBody() != null
+                        ? LastLevelBreakability.ACCEPT_INLINE_CHAIN
+                        : LastLevelBreakability.CHECK_INNER);￿
         if (node.getEnclosingExpression() != null) {
             scan(node.getEnclosingExpression(), null);
             builder.breakOp();

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -688,7 +688,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 BreakBehaviours.preferBreakingLastInnerLevel(true),
                 node.getClassBody() != null
                         ? LastLevelBreakability.ACCEPT_INLINE_CHAIN
-                        : LastLevelBreakability.CHECK_INNER);￿
+                        : LastLevelBreakability.CHECK_INNER);
         if (node.getEnclosingExpression() != null) {
             scan(node.getEnclosingExpression(), null);
             builder.breakOp();

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21954779.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21954779.output
@@ -23,8 +23,9 @@ class B21954779 {
             }
         });
 
-        getContext().getErrorReporter().log(new RuntimeException(
-                "Called layout with a non-zero segment index: " + segmentIndex));
+        getContext()
+                .getErrorReporter()
+                .log(new RuntimeException("Called layout with a non-zero segment index: " + segmentIndex));
 
         bind(new Key<ServiceMethodRunner<SyncReferenceNumberRequest, SyncReferenceNumberResponse>>() {});
 


### PR DESCRIPTION
## Before this PR

[An early change](https://github.com/palantir/palantir-java-format/commit/96fad677b1f8081ce0bf0746457e4064c2c59757#diff-7dfa8e2a4f62dbfd3c2417db1c953ab5R671) allows inlining an expression if the last level is a constructor call e.g. `new SomeClass`. This is good for anonymous classes, as we can inline the `new SomeClass()` bit and let the body use the next lines.
However, it's not good for new class expressions without a custom body, because it ends up allowing an inlining that breaks at the new class' parameters, e.g.

```java
long someVariable = foo(a, b, new Foo(
        x, y, z));
```

## After this PR
==COMMIT_MSG==
Don't inline constructor calls without a custom body (i.e. if they are not anonymous classes).

Fixes #153.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

