### PR TITLE
service load only once

### DIFF
--- a/changelog/@unreleased/pr-158.v2.yml
+++ b/changelog/@unreleased/pr-158.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: 'Only service load the formatter implementation once, rather than once
+    per gradle project. This avoids gradle potentially exceedding the `MaxMetaspaceSize`
+    and throwing `java.lang.OutOfMemoryError: Metaspace`.'
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/158

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/JavaFormatExtension.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/JavaFormatExtension.java
@@ -16,22 +16,30 @@
 
 package com.palantir.javaformat.gradle;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import com.palantir.javaformat.java.FormatterService;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 import org.gradle.api.artifacts.Configuration;
 
 public class JavaFormatExtension {
     private final Configuration configuration;
+    private final Supplier<FormatterService> memoizedService;
 
     public JavaFormatExtension(Configuration configuration) {
         this.configuration = configuration;
+        this.memoizedService = Suppliers.memoize(this::serviceLoadInternal);
     }
 
     public FormatterService serviceLoad() {
+        return memoizedService.get();
+    }
+
+    private FormatterService serviceLoadInternal() {
         URL[] jarUris = configuration.getFiles().stream()
                 .map(file -> {
                     try {

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/spotless/PalantirJavaFormatStep.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/spotless/PalantirJavaFormatStep.java
@@ -3,7 +3,6 @@ package com.palantir.javaformat.gradle.spotless;
 import com.diffplug.spotless.FileSignature;
 import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
-import com.google.common.base.Suppliers;
 import com.palantir.javaformat.gradle.JavaFormatExtension;
 import com.palantir.javaformat.java.FormatterService;
 import java.io.File;
@@ -23,7 +22,7 @@ public final class PalantirJavaFormatStep {
     /** Creates a step which formats everything - code, import order, and unused imports. */
     public static FormatterStep create(Configuration palantirJavaFormat, JavaFormatExtension extension) {
         ensureImplementationNotDirectlyLoadable();
-        Supplier<FormatterService> memoizedService = Suppliers.memoize(extension::serviceLoad);
+        Supplier<FormatterService> memoizedService = extension::serviceLoad;
         return FormatterStep.createLazy(
                 NAME, () -> new State(palantirJavaFormat.getFiles(), memoizedService), State::createFormat);
     }


### PR DESCRIPTION
## Before this PR

spotless is service loading the implementation once per gradle project, even though it's guaranteed to be the same for the entire gradle build.

This leads to some people's gradles dying by exceeding MaxMetaspaceSize.

## After this PR
==COMMIT_MSG==
Only service load the formatter implementation once.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

