### PR TITLE
don't try to inline too simple dotWithPrefix (no methods)

### DIFF
--- a/changelog/@unreleased/pr-161.v2.yml
+++ b/changelog/@unreleased/pr-161.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Only allow expressions with prefix to be inlined after a lambda/simple
+    expression if they contain method calls.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/161

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/LastLevelBreakability.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/LastLevelBreakability.java
@@ -28,7 +28,7 @@ public enum LastLevelBreakability {
     CHECK_INNER,
     /**
      * Behaves like {@link #ACCEPT_INLINE_CHAIN} if the current inlined levels are all <em>simple</em> (according to
-     * {@link com.palantir.javaformat.doc.Level#isSimpleLevel}), otherwise behave like {@link #CHECK_INNER}.
+     * {@link OpenOp#complexity()}), otherwise behave like {@link #CHECK_INNER}.
      */
     ACCEPT_INLINE_CHAIN_IF_SIMPLE_OTHERWISE_CHECK_INNER,
     ;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -2811,11 +2811,16 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         // Are there method invocations or field accesses after the prefix?
         boolean trailingDereferences = !prefixes.isEmpty() && getLast(prefixes) < items.size() - 1;
 
+        boolean hasMethodInvocations = items.stream().anyMatch(expr -> expr.getKind() == METHOD_INVOCATION);
+
         builder.open(OpenOp.builder()
                 .debugName("visitDotWithPrefix")
                 .plusIndent(plusFour)
                 .breakBehaviour(BreakBehaviours.preferBreakingLastInnerLevel(false))
-                .breakabilityIfLastLevel(LastLevelBreakability.ACCEPT_INLINE_CHAIN_IF_SIMPLE_OTHERWISE_CHECK_INNER)
+                .breakabilityIfLastLevel(
+                        hasMethodInvocations
+                                ? LastLevelBreakability.ACCEPT_INLINE_CHAIN_IF_SIMPLE_OTHERWISE_CHECK_INNER
+                                : LastLevelBreakability.CHECK_INNER)
                 .partialInlineability(PartialInlineability.IF_FIRST_LEVEL_FITS)
                 .columnLimitBeforeLastBreak(METHOD_CHAIN_COLUMN_LIMIT)
                 .isSimple(!trailingDereferences)

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24909927.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24909927.output
@@ -265,8 +265,9 @@ class Xxx {
                                                                 .xxxXxxxxxx(XxxxxxxXxxx.xxxXxxxxxx()
                                                                         .xxxXxxxxxxx(Xxxxxxxx.XXXX)
                                                                         .xxxXxxxxxXxxx(XxxxxxXxxx.xxxXxxxxxx()
-                                                                                .xxxXxxxxxXxxx(XxxxxxXxxx
-                                                                                        .XXX_XXXXXXXXXXXXXXX_XXXX_XXXXXXX_XXXXX_XXXXX)
+                                                                                .xxxXxxxxxXxxx(
+                                                                                        XxxxxxXxxx
+                                                                                                .XXX_XXXXXXXXXXXXXXX_XXXX_XXXXXXX_XXXXX_XXXXX)
                                                                                 .xxxXxxxXxxxxx(XxxxXxxxxx.xxxXxxxxxx()
                                                                                         .xxxXxxxxxxxxXxxxx(
                                                                                                 XxxxXxxxxxx.xxxXxxxxxx()
@@ -316,8 +317,9 @@ class Xxx {
                                                                 .xxxXxxxxxx(XxxxxxxXxxx.xxxXxxxxxx()
                                                                         .xxxXxxxxxxx(Xxxxxxxx.XXXX)
                                                                         .xxxXxxxxxXxxx(XxxxxxXxxx.xxxXxxxxxx()
-                                                                                .xxxXxxxxxXxxx(XxxxxxXxxx
-                                                                                        .XXX_XXXXXXXXXXXXXXX_XXXX_XXXXXXX_XXXXX_XXXXX)
+                                                                                .xxxXxxxxxXxxx(
+                                                                                        XxxxxxXxxx
+                                                                                                .XXX_XXXXXXXXXXXXXXX_XXXX_XXXXXXX_XXXXX_XXXXX)
                                                                                 .xxxXxxxXxxxxx(XxxxXxxxxx.xxxXxxxxxx()
                                                                                         .xxxXxxxxxxxxXxxxx(
                                                                                                 XxxxXxxxxxx.xxxXxxxxxx()

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-expression-lambdas-2.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-expression-lambdas-2.input
@@ -1,0 +1,7 @@
+class PalantirExpressionLambdas {
+    void foo() {
+        this.sequentialTableFactory = SequentialTableFactory.create(
+                ObjectMappers.newServerObjectMapper(), Event.class, txnManager::getTimestampService, () ->
+                        SequentialTableFactory.Strategy.V1);
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-expression-lambdas-2.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-expression-lambdas-2.output
@@ -1,0 +1,9 @@
+class PalantirExpressionLambdas {
+    void foo() {
+        this.sequentialTableFactory = SequentialTableFactory.create(
+                ObjectMappers.newServerObjectMapper(),
+                Event.class,
+                txnManager::getTimestampService,
+                () -> SequentialTableFactory.Strategy.V1);
+    }
+}


### PR DESCRIPTION
## Before this PR

#147 didn't ban a degenerate case of split lambda where certain "dotted expressions with prefix" can still end up being split even though they are very simple. See the [palantir-expression-lambdas-2.input test](https://github.com/palantir/palantir-java-format/pull/161/files#diff-7e7925644915b216036d8fc882ccd577).

## After this PR
==COMMIT_MSG==
Only allow expressions with prefix to be inlined after a lambda/simple expression if they contain method calls.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

