### PR TITLE
Support source 9 everywhere

### DIFF
--- a/changelog/@unreleased/pr-163.v2.yml
+++ b/changelog/@unreleased/pr-163.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Support source=9 across all formatter steps and pull out parsing into
+    a single function.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/163

--- a/changelog/@unreleased/pr-163.v2.yml
+++ b/changelog/@unreleased/pr-163.v2.yml
@@ -1,6 +1,5 @@
 type: fix
 fix:
-  description: Support source=9 across all formatter steps and pull out parsing into
-    a single function.
+  description: Support source=9 across all formatter steps.
   links:
   - https://github.com/palantir/palantir-java-format/pull/163

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -17,6 +17,7 @@ package com.palantir.javaformat.java;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.palantir.javaformat.java.JavaFormatterOptions.Style;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.base.Joiner;
@@ -434,5 +435,15 @@ public final class FormatterTest {
                         + " unbroken sentence moving from topic to topic so that no-one had a"
                         + " chance to interrupt;\n"
                         + "}\n");
+    }
+
+    @Test
+    void canParse_java9_private_interface_methods() {
+        assertThatCode(() -> Formatter.create()
+                        .formatSourceAndFixImports(""
+                                + "interface T {\n"
+                                + "    private static void foo() {}\n" //
+                                + "}"))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Before this PR

The main Formatter class parsed java code with `source=9` but the other two steps (StringWrapper, RemoveUnusedImports) didn't, and so failed on source=9 features like private interface methods:

```
com.palantir.javaformat.java.FormatterException: 298:40: error: private interface methods are not supported in -source 1.8
  (use -source 9 or higher to enable private interface methods)
	at com.palantir.javaformat.java.FormatterExceptions.fromJavacDiagnostics(FormatterExceptions.java:28)
	at com.palantir.javaformat.java.StringWrapper.parse(StringWrapper.java:443)
	at com.palantir.javaformat.java.StringWrapper.getReflowReplacements(StringWrapper.java:134)
```

These three share a bunch of parsing code that is pretty much identical.

## After this PR
==COMMIT_MSG==
Support source=9 across all formatter steps and pull our parsing to a single function.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

