### PR TITLE
Fix dangling ::methodReference

### DIFF
--- a/changelog/@unreleased/pr-164.v2.yml
+++ b/changelog/@unreleased/pr-164.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Method references are no longer split onto their own line unless the
+    expression they're referencing is also completely split.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/164

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/BreakBehaviour.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/BreakBehaviour.java
@@ -29,6 +29,16 @@ public abstract class BreakBehaviour {
         R preferBreakingLastInnerLevel(boolean keepIndentWhenInlined);
 
         /**
+         * Attempt to inline the suffix of this level (which must be a {@link Level} and the last doc), recursing into
+         * the {@link Level} just before the last {@link Level} (if there is such a level) to see if that can be broken
+         * instead.
+         *
+         * <p>This behaves like {@link #breakThisLevel()} if we couldn't recurse into such an inner level, or if the
+         * suffix level doesn't fit on the last line.
+         */
+        R inlineSuffix();
+
+        /**
          * Break if by doing so all inner levels then fit on a single line. However, don't break if we can fit in the
          * {@link Doc docs} up to the first break (which might be nested inside the next doc if it's a {@link Level}),
          * in order to prevent exceeding the maxLength accidentally.
@@ -65,6 +75,14 @@ public abstract class BreakBehaviour {
                         try {
                             gen.writeObjectField("type", "preferBreakingLastInnerLevel");
                             gen.writeObjectField("keepIndentWhenInlined", keepIndentWhenInlined);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return null;
+                    })
+                    .inlineSuffix(() -> {
+                        try {
+                            gen.writeObjectField("type", "inlineSuffix");
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -918,8 +918,6 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         builder.open(OpenOp.builder()
                 .plusIndent(plusFour)
                 .debugName("methodReference")
-                // Would like to use CHECK_INNER but we'd have to check in the _first_ level rather than the last
-                // level, which the current logic can't do yet.
                 .breakabilityIfLastLevel(LastLevelBreakability.CHECK_INNER)
                 .breakBehaviour(BreakBehaviours.inlineSuffix())
                 .build());

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -920,7 +920,8 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 .debugName("methodReference")
                 // Would like to use CHECK_INNER but we'd have to check in the _first_ level rather than the last
                 // level, which the current logic can't do yet.
-                .breakabilityIfLastLevel(LastLevelBreakability.ACCEPT_INLINE_CHAIN)
+                .breakabilityIfLastLevel(LastLevelBreakability.CHECK_INNER)
+                .breakBehaviour(BreakBehaviours.inlineSuffix())
                 .build());
         scan(node.getQualifierExpression(), null);
         builder.open(ZERO);

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-dangling-method-reference.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-dangling-method-reference.input
@@ -1,0 +1,7 @@
+class PalantirDanglingMethodReference {
+    void foo() {
+        return engageNicely(
+                staleForksFigureBark, staleForksFigureConsecutiveFailedExecutions, isStaleForksFigureInProgress, this
+                        ::engageStaleForksUnsafely);
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-dangling-method-reference.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-dangling-method-reference.output
@@ -1,0 +1,9 @@
+class PalantirDanglingMethodReference {
+    void foo() {
+        return engageNicely(
+                staleForksFigureBark,
+                staleForksFigureConsecutiveFailedExecutions,
+                isStaleForksFigureInProgress,
+                this::engageStaleForksUnsafely);
+    }
+}


### PR DESCRIPTION
## Before this PR

We could end up with method reference invocations being split onto their own line which looks weird.

## After this PR
==COMMIT_MSG==
Method references are no longer split onto their own line unless the expression they're referencing is also completely split.

Fixes #130 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

