### PR TITLE
inline annotation args

### DIFF
--- a/changelog/@unreleased/pr-191.v2.yml
+++ b/changelog/@unreleased/pr-191.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Long annotation args are now partially inlined, such that concatenated
+    strings look better.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/191

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -1321,7 +1321,10 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     public void visitAnnotationArgument(AssignmentTree node) {
         boolean isArrayInitializer = node.getExpression().getKind() == NEW_ARRAY;
         sync(node);
-        builder.open(isArrayInitializer ? ZERO : plusFour);
+        builder.open(
+                isArrayInitializer ? ZERO : plusFour,
+                BreakBehaviours.preferBreakingLastInnerLevel(true),
+                LastLevelBreakability.ACCEPT_INLINE_CHAIN_IF_SIMPLE_OTHERWISE_CHECK_INNER);
         scan(node.getVariable(), null);
         builder.space();
         token("=");

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20529113.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20529113.output
@@ -8,9 +8,8 @@
 @BugPattern(
         name = "AsyncFunctionReturnsImmediate",
         summary = SIMPLIFY,
-        explanation =
-                "If an AsyncFunction always returns immediateFuture() and never throws, it can "
-                        + "be replaced with a Function.",
+        explanation = "If an AsyncFunction always returns immediateFuture() and never throws, it can "
+                + "be replaced with a Function.",
         category = GUAVA,
         severity = NOT_A_PROBLEM,
         maturity = EXPERIMENTAL)

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B65214682.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B65214682.output
@@ -7,9 +7,8 @@
 @BugPattern(
         name = "AsyncFunctionReturnsImmediate",
         summary = SIMPLIFY,
-        explanation =
-                "If an AsyncFunction always returns immediateFuture() and never throws, it can "
-                        + "be replaced with a Function.",
+        explanation = "If an AsyncFunction always returns immediateFuture() and never throws, it can "
+                + "be replaced with a Function.",
         category = GUAVA,
         severity = NOT_A_PROBLEM,
         maturity = EXPERIMENTAL)


### PR DESCRIPTION
## Before this PR

Long annotation args would be split onto the next line.

## After this PR
==COMMIT_MSG==
Long annotation args are now partially inlined, such that concatenated strings look better.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

