### PR TITLE
Fix lineSpan

### DIFF
--- a/changelog/@unreleased/pr-193.v2.yml
+++ b/changelog/@unreleased/pr-193.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix bug in 0.3.24 that could sometimes cause a NPE when encountering
+    a newline right after a string concatenation expression.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/193

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -85,7 +85,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -3307,8 +3306,6 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     int lineSpan(Tree node) {
         ImmutableRangeMap<Integer, ? extends Input.Token> positionTokenMap =
                 builder.getInput().getPositionTokenMap();
-        Function<Input.Token, Integer> lineNumberAt =
-                token -> builder.getInput().getLineNumber(token.getTok().getPosition());
 
         int startPosition = getStartPosition(node);
         int endPosition = getEndPosition(node, getCurrentPath());
@@ -3320,7 +3317,11 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         }
         Input.Token startToken = positionTokenMap.get(startPosition);
         Input.Token endToken = positionTokenMap.get(endPosition);
-        return lineNumberAt.apply(endToken) - lineNumberAt.apply(startToken) + 1;
+        return lineNumberAt(endToken) - lineNumberAt(startToken) + 1;
+    }
+
+    private int lineNumberAt(Input.Token token) {
+        return builder.getInput().getLineNumber(token.getTok().getPosition());
     }
 
     /** Returns true if {@code atLeastM} of the expressions in the given column are the same kind. */

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-10.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-10.input
@@ -16,5 +16,12 @@ class Palantir10 {
                     + "bar" + THING + "baz");
         foo("foo"
                 + "bar" + THING + "baz");
+
+        // This causes an NPE if we're not careful when getting the last token of the binary expression
+        if (!partialDataSourceType.equals(dataSourceType)) {
+            throw new ClientException("You may not use a " + partialDataSourceType
+                    + " partial in a " + dataSourceType + " query. Caused by partial \"" + partialName + "\""
+            );
+        }
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-10.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-10.output
@@ -13,5 +13,11 @@ class Palantir10 {
         // Test that we still reflow short string concatenations (spanning exactly 2 lines)
         foo("foo" + "bar" + THING + "baz");
         foo("foo" + "bar" + THING + "baz");
+
+        // This causes an NPE if we're not careful when getting the last token of the binary expression
+        if (!partialDataSourceType.equals(dataSourceType)) {
+            throw new ClientException("You may not use a " + partialDataSourceType + " partial in a " + dataSourceType
+                    + " query. Caused by partial \"" + partialName + "\"");
+        }
     }
 }


### PR DESCRIPTION
## Before this PR

#192 added a function `lineSpan` that could sometimes throw a NPE.

## After this PR
==COMMIT_MSG==
Fix lineSpan function to not throw NPE.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

