### PR TITLE
Inline case statements with single block body

### DIFF
--- a/changelog/@unreleased/pr-252.v2.yml
+++ b/changelog/@unreleased/pr-252.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Case statements with a body consisting of a single block now inline
+    their block.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/252

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -1511,7 +1511,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             builder.open(plusTwo);
             builder.forcedBreak();
             builder.blankLineWanted(BlankLineWanted.PRESERVE);
-            visitStatements(node.getBody().getStatements());
+            visitStatements(node.getBody().getStatements(), false);
             builder.close();
             builder.forcedBreak();
             builder.blankLineWanted(BlankLineWanted.NO);
@@ -1817,8 +1817,13 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             scan(node.getExpression(), null);
             token(":");
         }
-        builder.open(plusTwo);
-        visitStatements(node.getStatements());
+        boolean isBlock =
+                node.getStatements().size() == 1 && node.getStatements().get(0).getKind() == BLOCK;
+        builder.open(isBlock ? ZERO : plusTwo);
+        if (isBlock) {
+            builder.space();
+        }
+        visitStatements(node.getStatements(), isBlock);
         builder.close();
         return null;
     }
@@ -2115,7 +2120,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             } else {
                 builder.blankLineWanted(BlankLineWanted.PRESERVE);
             }
-            visitStatements(node.getStatements());
+            visitStatements(node.getStatements(), false);
             builder.close();
             builder.forcedBreak();
             builder.close();
@@ -2149,13 +2154,15 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         }
     }
 
-    private void visitStatements(List<? extends StatementTree> statements) {
+    private void visitStatements(List<? extends StatementTree> statements, boolean inlineFirst) {
         boolean first = true;
         PeekingIterator<StatementTree> it = Iterators.peekingIterator(statements.iterator());
         dropEmptyDeclarations();
         while (it.hasNext()) {
             StatementTree tree = it.next();
-            builder.forcedBreak();
+            if (!(inlineFirst && first)) {
+                builder.forcedBreak();
+            }
             if (!first) {
                 builder.blankLineWanted(BlankLineWanted.PRESERVE);
             }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.input
@@ -1,0 +1,26 @@
+public class Palantir12 {
+    private void foo() {
+        switch (true) {
+            case false:
+            {
+                String foo = "bar";
+                return 5;
+            }
+            {
+                // second block should cause first one not to inline
+            }
+            case true:
+            {
+                String foo = "bar";
+                return 5;
+            }
+            default:
+            {
+                {
+                    String foo = "bar";
+                }
+                return 5;
+            }
+        }
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.input
@@ -1,4 +1,4 @@
-public class Palantir12 {
+public class PalantirCaseStatementsBlock {
     private void foo() {
         switch (true) {
             case false:

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.output
@@ -1,4 +1,4 @@
-public class Palantir12 {
+public class PalantirCaseStatementsBlock {
     private void foo() {
         switch (true) {
             case false:

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-case-statements-block.output
@@ -1,0 +1,24 @@
+public class Palantir12 {
+    private void foo() {
+        switch (true) {
+            case false:
+                {
+                    String foo = "bar";
+                    return 5;
+                }
+                {
+                    // second block should cause first one not to inline
+                }
+            case true: {
+                String foo = "bar";
+                return 5;
+            }
+            default: {
+                {
+                    String foo = "bar";
+                }
+                return 5;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR

Case statements with a block body get unnecessarily put onto the next line, causing checkstyle to complain.

Sometimes it's not possible to avoid this pattern, if you are defining variables inside the case statement.

## After this PR
==COMMIT_MSG==
Case statements with a body consisting of a single block now inline their block.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

