### PR TITLE
Fix possible exception with initializer body close to column limit

### DIFF
--- a/changelog/@unreleased/pr-257.v2.yml
+++ b/changelog/@unreleased/pr-257.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix edge case with empty levels causing formattings very close to the
+    column limit to throw.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/257

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/Level.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 /** A {@code Level} inside a {@link Doc}. */
@@ -262,10 +263,7 @@ public final class Level extends Doc {
 
         // Note: we are not checking if the brokenState produced one extra line compared to state, as this can be
         // misleading if there is no level but a single comment that got reflowed onto multiple lines (see palantir-11).
-        boolean anyLevelWasBroken = docs.stream()
-                .filter(doc -> doc instanceof Level)
-                .map(doc -> ((Level) doc))
-                .anyMatch(level -> !brokenState.isOneLine(level));
+        boolean anyLevelWasBroken = getNonEmptyInnerLevels().anyMatch(level -> !brokenState.isOneLine(level));
 
         if (!anyLevelWasBroken) {
             return Optional.of(brokenState);
@@ -278,15 +276,19 @@ public final class Level extends Doc {
         }
         State partiallyInlinedState = partiallyInlinedStateOpt.get();
 
-        boolean bodyIsComplex = this.docs.stream()
-                .filter(doc -> doc instanceof Level)
-                .map(doc -> ((Level) doc))
-                .anyMatch(il -> il.openOp.complexity() == Complexity.COMPLEX);
+        boolean bodyIsComplex = getNonEmptyInnerLevels().anyMatch(il -> il.openOp.complexity() == Complexity.COMPLEX);
 
         if (bodyIsComplex || partiallyInlinedState.numLines() < brokenState.numLines()) {
             return Optional.of(partiallyInlinedState);
         }
         return Optional.empty();
+    }
+
+    private Stream<Level> getNonEmptyInnerLevels() {
+        return docs.stream()
+                .filter(doc -> doc instanceof Level)
+                .map(doc -> ((Level) doc))
+                .filter(doc -> StartsWithBreakVisitor.INSTANCE.visit(doc) != Result.EMPTY);
     }
 
     private Optional<State> tryInlinePrefixOntoCurrentLine(
@@ -297,15 +299,9 @@ public final class Level extends Doc {
             Obs.ExplorationNode explorationNode) {
         // Find the last level, skipping empty levels (that contain nothing, or are made up
         // entirely of other empty levels).
-        List<Level> innerLevels = this.docs.stream()
-                .filter(doc -> doc instanceof Level)
-                .map(doc -> ((Level) doc))
-                .collect(Collectors.toList());
-
         // Last level because there might be other in-between levels after the initial break like `new
-        // int[]
-        // {`, and we want to skip those.
-        Level lastLevel = innerLevels.stream()
+        // int[] {`, and we want to skip those.
+        Level lastLevel = getNonEmptyInnerLevels()
                 .filter(doc -> StartsWithBreakVisitor.INSTANCE.visit(doc) != Result.EMPTY)
                 .collect(GET_LAST_COLLECTOR)
                 .orElseThrow(() ->

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-12.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-12.input
@@ -1,0 +1,25 @@
+public class Palantir12 {
+
+    @Override
+    public
+    void
+    foo() {
+        new DogWalker()
+                .walk(
+                        DogBreed.FOX_TERRIER,
+                        new RoadWalker<Void>() {
+                            @Override
+                            public Void call(Dog dog) {
+                                routes.forEach((route) -> route.getCoordinates()
+                                        .forEach((coordinate) -> {
+                                            coordinate.getOtherDogs().forEach(otherDog -> {
+                                                if (!dog.likes(otherDog)) {
+                                                    badEncounters.computeIfAbsent(coordinate, _x -> new HashSet<>())
+                                                            .add(dog).add(otherDog);
+                                                }
+                                            });
+                                        }));
+                            }
+                        });
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-12.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-12.output
@@ -1,0 +1,21 @@
+public class Palantir12 {
+
+    @Override
+    public void foo() {
+        new DogWalker().walk(DogBreed.FOX_TERRIER, new RoadWalker<Void>() {
+            @Override
+            public Void call(Dog dog) {
+                routes.forEach((route) -> route.getCoordinates().forEach((coordinate) -> {
+                    coordinate.getOtherDogs().forEach(otherDog -> {
+                        if (!dog.likes(otherDog)) {
+                            badEncounters
+                                    .computeIfAbsent(coordinate, _x -> new HashSet<>())
+                                    .add(dog)
+                                    .add(otherDog);
+                        }
+                    });
+                }));
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Before this PR

When formatting far-off (close to 120 characters) lambda or assignment body, the formatting code could throw an exception.
This would happen if the body contained an empty level, such as the case when e.g. doing `new SomeClass<>()`: there is an empty level created for the type arguments inside `<>`, but it's empty because there are no type arguments. 

This would throw off the logic that decides whether trying to put such body onto the next line results in it taking only one line (in `handle_breakOnlyIfInnerLevelsThenFitOnOneLine`).
It could first infer that the empty level was broken (marked as such because the column would have already exceeded 120 columns), but then later down the line `tryInlinePrefixOntoCurrentLine` would try to find this broken level, only this time it would filter out empty levels, and so never find that level and throw.

## After this PR
==COMMIT_MSG==
Fix edge case with empty levels causing formattings very close to the column limit to throw.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

