### PR TITLE
CodeStyleManagerDecorator extends CodeStyleManagerImpl

### DIFF
--- a/changelog/@unreleased/pr-313.v2.yml
+++ b/changelog/@unreleased/pr-313.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Explicitly extend the IntelliJ CodeStyleManagerImpl so that any methods
+    added in newer releases are inherited automatically with a reasonable default
+    implementation.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/313

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
@@ -30,6 +30,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.codeStyle.DocCommentSettings;
 import com.intellij.psi.codeStyle.FormattingModeAwareIndentAdjuster;
 import com.intellij.psi.codeStyle.Indent;
+import com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.ThrowableRunnable;
 import java.util.Collection;
@@ -38,13 +39,22 @@ import javax.annotation.Nullable;
 /**
  * Decorates the {@link CodeStyleManager} abstract class by delegating to a concrete implementation instance (likely
  * IJ's default instance).
+ *
+ * Explicitly extend the IntelliJ {@link #CodeStyleManagerImpl} so that any methods added in newer releases are
+ * inherited automatically with a reasonable default implementation.
+ *
+ * The https://github.com/JetBrains/intellij-community/commit/2d5740176cc9206db2d5ab5d8f67cec74b85a017
+ * added a CodeManager#scheduleReformatWhenSettingsComputed(PsiFile) method in idea/202.5103.13 where the
+ * default implementation throws an UnsuportedOperationException.
+ * See https://youtrack.jetbrains.com/issue/IDEA-244645 for more details.
  */
 @SuppressWarnings("deprecation")
-class CodeStyleManagerDecorator extends CodeStyleManager implements FormattingModeAwareIndentAdjuster {
+class CodeStyleManagerDecorator extends CodeStyleManagerImpl implements FormattingModeAwareIndentAdjuster {
 
     private final CodeStyleManager delegate;
 
-    CodeStyleManagerDecorator(CodeStyleManager delegate) {
+    CodeStyleManagerDecorator(Project project, CodeStyleManager delegate) {
+        super(project);
         this.delegate = delegate;
     }
 

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
@@ -82,12 +82,12 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
             Caffeine.newBuilder().maximumSize(1).build(PalantirCodeStyleManager::createFormatter);
 
     public PalantirCodeStyleManager(@NotNull Project project) {
-        super(new CodeStyleManagerImpl(project));
+        super(project, new CodeStyleManagerImpl(project));
     }
 
     @NonInjectable
     PalantirCodeStyleManager(@NotNull CodeStyleManager original) {
-        super(original);
+        super(original.getProject(), original);
     }
 
     static Map<TextRange, String> getReplacements(


### PR DESCRIPTION
## Before this PR
Using this plugin in IntelliJ versions newer than 202.5103.13 leads to the following exception and failure to format newly created Java files.

Steps to reproduce in an existing Java project:
- File > New > Java Class
- Provide a name "FooTest"
- Receive "Cannot Create Class" error below
- Note that the file & class are actually created

https://github.com/JetBrains/intellij-community/commit/2d5740176cc9206db2d5ab5d8f67cec74b85a017 added a `CodeStyleManager#scheduleReformatWhenSettingsComputed(PsiFile)` instance method in `idea/202.5103.13` where the default implementation throws an UnsuportedOperationException.

See https://youtrack.jetbrains.com/issue/IDEA-244645 for more details (though that stacktrace shows similar bug with [Eclipse Code Formatter plugin](https://github.com/krasa/EclipseCodeFormatter) as used by default with gradle-baseline.

```
2020-06-27 17:56:32,707 [  37292]   INFO - es.ui.CreateFromTemplateDialog -  
java.lang.UnsupportedOperationException
	at com.intellij.psi.codeStyle.CodeStyleManager.scheduleReformatWhenSettingsComputed(CodeStyleManager.java:351)
	at com.intellij.ide.fileTemplates.JavaCreateFromTemplateHandler.createClassOrInterface(JavaCreateFromTemplateHandler.java:78)
	at com.intellij.ide.fileTemplates.JavaCreateFromTemplateHandler.createFromTemplate(JavaCreateFromTemplateHandler.java:118)
	at com.intellij.ide.fileTemplates.FileTemplateUtil.lambda$createFromTemplate$5(FileTemplateUtil.java:336)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl$2.run(WriteCommandAction.java:115)
	at com.intellij.openapi.application.RunResult.run(RunResult.java:35)
	at com.intellij.openapi.command.WriteCommandAction.lambda$performWriteCommandAction$1(WriteCommandAction.java:246)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:980)
	at com.intellij.openapi.command.WriteCommandAction.lambda$performWriteCommandAction$2(WriteCommandAction.java:245)
	at com.intellij.openapi.command.WriteCommandAction.lambda$doExecuteCommand$4(WriteCommandAction.java:303)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:211)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:187)
	at com.intellij.openapi.command.WriteCommandAction.doExecuteCommand(WriteCommandAction.java:305)
	at com.intellij.openapi.command.WriteCommandAction.performWriteCommandAction(WriteCommandAction.java:244)
	at com.intellij.openapi.command.WriteCommandAction.execute(WriteCommandAction.java:225)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.compute(WriteCommandAction.java:117)
	at com.intellij.ide.fileTemplates.FileTemplateUtil.createFromTemplate(FileTemplateUtil.java:336)
	at com.intellij.ide.fileTemplates.FileTemplateUtil.createFromTemplate(FileTemplateUtil.java:262)
	at com.intellij.ide.fileTemplates.ui.CreateFromTemplateDialog.doCreate(CreateFromTemplateDialog.java:136)
	at com.intellij.ide.fileTemplates.ui.CreateFromTemplateDialog.create(CreateFromTemplateDialog.java:104)
	at com.intellij.psi.impl.file.JavaDirectoryServiceImpl.createClassFromTemplate(JavaDirectoryServiceImpl.java:179)
	at com.intellij.psi.impl.file.JavaDirectoryServiceImpl.createClass(JavaDirectoryServiceImpl.java:104)
	at com.intellij.psi.impl.file.JavaDirectoryServiceImpl.createClass(JavaDirectoryServiceImpl.java:96)
	at com.intellij.ide.actions.CreateClassAction.doCreate(CreateClassAction.java:107)
	at com.intellij.ide.actions.CreateClassAction.doCreate(CreateClassAction.java:28)
	at com.intellij.ide.actions.CreateTemplateInPackageAction.lambda$checkOrCreate$2(CreateTemplateInPackageAction.java:114)
	at com.intellij.openapi.project.DumbService.computeWithAlternativeResolveEnabled(DumbService.java:353)
	at com.intellij.ide.actions.CreateTemplateInPackageAction.checkOrCreate(CreateTemplateInPackageAction.java:113)
	at com.intellij.ide.actions.CreateTemplateInPackageAction.createFile(CreateTemplateInPackageAction.java:60)
	at com.intellij.ide.actions.CreateFromTemplateAction$1.createFile(CreateFromTemplateAction.java:70)
	at com.intellij.ide.actions.CreateFromTemplateAction$1.createFile(CreateFromTemplateAction.java:65)
	at com.intellij.ide.actions.CreateFileFromTemplateDialog$NonBlockingPopupBuilderImpl$1.create(CreateFileFromTemplateDialog.java:262)
	at com.intellij.ide.actions.ElementCreator.lambda$tryCreate$0(ElementCreator.java:69)
	at com.intellij.ide.actions.ElementCreator.lambda$executeCommand$1(ElementCreator.java:90)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:220)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:177)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:167)
	at com.intellij.ide.actions.ElementCreator.executeCommand(ElementCreator.java:84)
	at com.intellij.ide.actions.ElementCreator.tryCreate(ElementCreator.java:68)
	at com.intellij.ide.actions.CreateFileFromTemplateDialog$NonBlockingPopupBuilderImpl.createElement(CreateFileFromTemplateDialog.java:311)
	at com.intellij.ide.actions.CreateFileFromTemplateDialog$NonBlockingPopupBuilderImpl.lambda$show$2(CreateFileFromTemplateDialog.java:285)
	at com.intellij.ide.ui.newItemPopup.NewItemSimplePopupPanel$1.keyPressed(NewItemSimplePopupPanel.java:103)
	at java.desktop/java.awt.Component.processKeyEvent(Component.java:6608)
	at java.desktop/javax.swing.JComponent.processKeyEvent(JComponent.java:2852)
	at java.desktop/java.awt.Component.processEvent(Component.java:6427)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5025)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4857)
	at java.desktop/java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1950)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:878)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1148)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:1017)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:843)
	at com.intellij.ide.IdeKeyboardFocusManager.dispatchEvent(IdeKeyboardFocusManager.java:41)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4906)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2773)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4857)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:778)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:751)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:749)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:748)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:967)
	at com.intellij.ide.IdeEventQueue.dispatchKeyEvent(IdeEventQueue.java:892)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:833)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:744)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:449)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:503)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

IntelliJ build info
```
IntelliJ IDEA 2020.2 EAP (Community Edition)
Build #IC-202.5958.24, built on June 25, 2020
Runtime version: 11.0.7+10-b944.13 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
macOS 10.15.5
GC: ParNew, ConcurrentMarkSweep
Memory: 1981M
Cores: 8
Non-Bundled Plugins: IdeaVIM, Key Promoter X, com.github.kornilovaL.flamegraphProfiler, com.github.pshirshov.bytecodeeditor, CheckStyle-IDEA, Error-prone plugin, JOL, com.dubreuia, com.intellij.bigdecimal-folding, palantir-java-format, org.intellij.scala, InplaceRefactoring.InplaceRefactoring, ru.yole.jitwatch-intellij, PythonCore
```

## After this PR
==COMMIT_MSG==
Explicitly extend the IntelliJ CodeStyleManagerImpl so that any methods added in newer releases are inherited automatically with a reasonable default implementation.

==COMMIT_MSG==

## Possible downsides?
There may be cases where `CodeStyleManagerDecorator` should intercept new methods added to `CodeStyleManagerImpl` in the future and handle them in a different fashion.