### PR TITLE
Fix develop by bumping intellij

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -22,7 +22,7 @@ apply from: rootProject.file('gradle/publish-jar.gradle')
 intellij {
     pluginName = "palantir-java-format"
     updateSinceUntilBuild = true
-    version = "IU-193.5233-EAP-CANDIDATE-SNAPSHOT"
+    version = "IU-202.6397.94"
     plugins = ['java']
 }
 


### PR DESCRIPTION
## Before this PR
We depend on a snapshot version of intellij that has now been deleted.

## After this PR
Depend on the most recent release version.

## Possible downsides?
None, as this released version is way newer than the snapshot.

