### PR TITLE
Add runtime dependency on palantir-java-format

### DIFF
--- a/changelog/@unreleased/pr-351.v2.yml
+++ b/changelog/@unreleased/pr-351.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Specify gradle-palantir-java-format's dependency on palantir-java-format
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/351

--- a/gradle-palantir-java-format/build.gradle
+++ b/gradle-palantir-java-format/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation project(':palantir-java-format-spi')
     
-    runtimeOnly project(':palantir-java-format')
+    provided project(':palantir-java-format')
 
     testImplementation 'com.netflix.nebula:nebula-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/gradle-palantir-java-format/build.gradle
+++ b/gradle-palantir-java-format/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation gradleApi()
     implementation 'com.google.guava:guava'
     implementation project(':palantir-java-format-spi')
+    
+    runtimeOnly project(':palantir-java-format')
 
     testImplementation 'com.netflix.nebula:nebula-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
## Before this PR
The build.gradle did not specify a dependency on com.palantir.javaformat:palantir-java-format, but PalantirJavaFormatProviderPlugin.java does add it during runtime.


## After this PR

==COMMIT_MSG==
Specify gradle-palantir-java-format's dependency on palantir-java-format
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

