### PR TITLE
[stacked onto fw/java14] different IntelliJ setup 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,6 @@ subprojects {
     sourceCompatibility = 11
     targetCompatibility = 11
 
-    // if (JavaVersion.current() >= JavaVersion.VERSION_14) {
-    //     sourceCompatibility = 14
-    //     targetCompatibility = 14
-    // }
-
     tasks.withType(Checkstyle) {
         enabled = false
     }
@@ -67,31 +62,19 @@ subprojects {
     tasks.withType(Test) {
         systemProperty 'recreate', System.getProperty('recreate', 'false')
     }
-
-    idea {
-        module.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
-    }
 }
 
-idea.project.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
-
-    // idea.project.settings {
-    //     compiler {
-    //         javac {
-    //             // Tell idea about the exported internal javac apis
-    //             moduleJavacAdditionalOptions = [
-    //                     'palantir-java-format': '--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED ' +
-    //                             '--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED ' +
-    //                             '--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED ' +
-    //                             '--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED ' +
-    //                             '--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED ' +
-    //                             '--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED']
-    //         }
-    //     }
-    // }
-
+/**
+ * There is a bunch of truly snowflaky stuff going on this project, because we have this Java14InputAstVisitor class
+ * which needs to implement some interface methods defined in com.sun.source.util.TreePathScanner. These new methods
+ * are only accessible if
+ */
 idea.project.ipr.withXml { xml ->
-    xml.asNode().component.find({ it.'@name' == 'CompilerConfiguration' }).value().add(new XmlParser().parseText('<option name="USE_RELEASE_OPTION" value="false" />'))
+    def compilerConfiguration = xml.asNode().component.find({ it.'@name' == 'CompilerConfiguration' })
+    compilerConfiguration.value().add(new XmlParser().parseText('<option name="USE_RELEASE_OPTION" value="false" />'))
+    // compilerConfiguration.bytecodeTargetLevel[0].attributes().target = '11'
+    // compilerConfiguration.bytecodeTargetLevel.module.find({ it.'@name' == 'palantir-java-format' }).attributes().target = "14"
+
     xml.asNode().value().add(new XmlParser().parseText('''
     <component name="JavacSettings">
         <option name="PREFER_TARGET_JDK_COMPILER" value="false" />

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,11 @@ idea.project.ipr.withXml { xml ->
      */
     def compilerConfiguration = xml.asNode().component.find({ it.'@name' == 'CompilerConfiguration' })
     compilerConfiguration.value().add(new XmlParser().parseText('<option name="USE_RELEASE_OPTION" value="false" />'))
-    compilerConfiguration.bytecodeTargetLevel.module.find({ it.'@name' == 'palantir-java-format' }).attributes().target = "14"
+    def module = compilerConfiguration.bytecodeTargetLevel.module.find({ it.'@name' == 'palantir-java-format' })
+    // Module is null on jdk11
+    if (module != null) {
+        module.attributes().target = "14"
+    }
 
     xml.asNode().value().add(new XmlParser().parseText('''
     <component name="JavacSettings">

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ subprojects {
     sourceCompatibility = 11
     targetCompatibility = 11
 
+    // if (JavaVersion.current() >= JavaVersion.VERSION_14) {
+    //     sourceCompatibility = 14
+    //     targetCompatibility = 14
+    // }
+
     tasks.withType(Checkstyle) {
         enabled = false
     }
@@ -62,19 +67,37 @@ subprojects {
     tasks.withType(Test) {
         systemProperty 'recreate', System.getProperty('recreate', 'false')
     }
+
+    idea {
+        module.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
+    }
 }
 
-idea.project.settings {
-    compiler {
-        javac {
-            // Tell idea about the exported internal javac apis
-            moduleJavacAdditionalOptions = [
-                    'palantir-java-format': '--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED ' +
-                            '--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED ' +
-                            '--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED ' +
-                            '--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED ' +
-                            '--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED ' +
-                            '--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED']
-        }
-    }
+idea.project.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
+
+    // idea.project.settings {
+    //     compiler {
+    //         javac {
+    //             // Tell idea about the exported internal javac apis
+    //             moduleJavacAdditionalOptions = [
+    //                     'palantir-java-format': '--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED ' +
+    //                             '--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED ' +
+    //                             '--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED ' +
+    //                             '--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED ' +
+    //                             '--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED ' +
+    //                             '--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED']
+    //         }
+    //     }
+    // }
+
+idea.project.ipr.withXml { xml ->
+    xml.asNode().component.find({ it.'@name' == 'CompilerConfiguration' }).value().add(new XmlParser().parseText('<option name="USE_RELEASE_OPTION" value="false" />'))
+    xml.asNode().value().add(new XmlParser().parseText('''
+    <component name="JavacSettings">
+        <option name="PREFER_TARGET_JDK_COMPILER" value="false" />
+        <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+        <module name="palantir-java-format" options="--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" />
+        </option>
+    </component>
+    '''))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -66,14 +66,18 @@ subprojects {
 
 /**
  * There is a bunch of truly snowflaky stuff going on this project, because we have this Java14InputAstVisitor class
- * which needs to implement some interface methods defined in com.sun.source.util.TreePathScanner. These new methods
- * are only accessible if
+ * which needs to implement some interface methods defined in com.sun.source.util.TreePathScanner, which varies
+ * depending on what JVM the formatter is running on!
  */
 idea.project.ipr.withXml { xml ->
+    /**
+     * Even though the p-j-f codebase has sourceCompat=11 and targetCompat=11, we have to convince IntelliJ to let us
+     * compile against methods from a newer JVM like visitYield, visitSwitchExpression etc. Hence why we turn off the
+     * --release flag (using USE_RELEASE_OPTION below)
+     */
     def compilerConfiguration = xml.asNode().component.find({ it.'@name' == 'CompilerConfiguration' })
     compilerConfiguration.value().add(new XmlParser().parseText('<option name="USE_RELEASE_OPTION" value="false" />'))
-    // compilerConfiguration.bytecodeTargetLevel[0].attributes().target = '11'
-    // compilerConfiguration.bytecodeTargetLevel.module.find({ it.'@name' == 'palantir-java-format' }).attributes().target = "14"
+    compilerConfiguration.bytecodeTargetLevel.module.find({ it.'@name' == 'palantir-java-format' }).attributes().target = "14"
 
     xml.asNode().value().add(new XmlParser().parseText('''
     <component name="JavacSettings">

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -65,3 +65,8 @@ tasks.test {
     // https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution
     systemProperty 'junit.jupiter.execution.parallel.mode.default', 'concurrent'
 }
+
+// necessary to compile Java14InputAstVisitor
+idea {
+    module.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
+}


### PR DESCRIPTION
## Before this PR

I'm not sure why, but I think all the nice first-class idea DSL config to add the java modules isn't working on my intellij version:
```
IntelliJ IDEA 2020.2 (Community Edition)
Build #IC-202.6397.94, built on July 27, 2020
Runtime version: 11.0.7+10-b944.20 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
macOS 10.14.6
GC: ParNew, ConcurrentMarkSweep
Memory: 1933M
Cores: 12
Non-Bundled Plugins: CheckStyle-IDEA, com.dubreuia, palantir-java-format, PythonCore
```

Pretending to be a brand new contributor to this repo, I did `git clean -xdf && ./gradlew idea` and then clicked IntelliJ's Build -> Rebuild project menu to do a complete fresh build.

<img width="1680" alt="Screenshot 2020-11-16 at 22 58 19" src="https://user-images.githubusercontent.com/3473798/99318248-420bb600-285f-11eb-9aab-eee98fa7a2aa.png">

I followed a bunch of the prompts it gave me, looking at the effect in the .ipr file each time.

![image](https://user-images.githubusercontent.com/3473798/99318357-754e4500-285f-11eb-8e73-64fbdf9764c4.png)

![image](https://user-images.githubusercontent.com/3473798/99318404-87c87e80-285f-11eb-9670-931a926459ea.png)

![image](https://user-images.githubusercontent.com/3473798/99318424-944cd700-285f-11eb-973c-423c7ed82edf.png)

Eventually, it got to the stage where I could do a `git clean -xdf && ./gradlew idea` and have the first rebuild Just Work(™).

## After this PR
==COMMIT_MSG==
Manually fiddle with the .ipr file's XML to allow the IntelliJ compiler to use java 14 things, but keep gradle's compiler on 11
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

