### PR TITLE
Format tests for switch expressions

### DIFF
--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -22,4 +22,25 @@ class ExpressionSwitch {
     };
     return val;
   }
+
+  enum Wrapping {
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
+  }
+
+  int wrapping(Wrapping w) {
+    switch (w) {
+        case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+            THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+            THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+    }
+  }
+
+  Supplier<Integer> lambda(int k) {
+    return () -> switch (k) {
+      case 0 -> true;
+      default -> false;
+    };
+  }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
@@ -28,4 +28,25 @@ class ExpressionSwitch {
                 };
         return val;
     }
+
+    enum Wrapping {
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
+    }
+
+    int wrapping(Wrapping w) {
+        switch (w) {
+            case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+                THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+                THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+        }
+    }
+
+    Supplier<Integer> closeDelimiter(int k) {
+        return () -> switch (k) {
+            case 0 -> true;
+            default -> false;
+        };
+    }
 }


### PR DESCRIPTION
Opening this PR to document some undesirable formatting of switch expressions.

Generally I'm more than willing to deal with bad formatting especially with new features. But these particular formatting choices are conflicting with the checkstyle rules applied by [gradle-baseline](https://github.com/palantir/gradle-baseline).

For more details, you can see the conflicting internal CI builds here:
- https://c.p.b/gh/f/mp/235199
- https://c.p.b/gh/f/mp/235206

@fawind @iamdanfox 