### PR TITLE
Fix line breaks in switch expression

### DIFF
--- a/changelog/@unreleased/pr-394.v2.yml
+++ b/changelog/@unreleased/pr-394.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix line breaks in switch expression
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/394

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -188,7 +188,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /** Whether to collapse empty blocks. */
-    enum CollapseEmptyOrNot {
+    protected enum CollapseEmptyOrNot {
         YES,
         NO;
 
@@ -202,7 +202,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /** Whether to allow leading blank lines in blocks. */
-    enum AllowLeadingBlankLine {
+    protected enum AllowLeadingBlankLine {
         YES,
         NO;
 
@@ -212,7 +212,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /** Whether to allow trailing blank lines in blocks. */
-    enum AllowTrailingBlankLine {
+    protected enum AllowTrailingBlankLine {
         YES,
         NO;
 
@@ -2111,7 +2111,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     /** Helper method for blocks. */
-    private void visitBlock(
+    protected void visitBlock(
             BlockTree node,
             CollapseEmptyOrNot collapseEmptyOrNot,
             AllowLeadingBlankLine allowLeadingBlankLine,

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -127,6 +127,7 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.TypeParameterTree;
@@ -1217,7 +1218,9 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     @Override
     public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
         sync(node);
-        boolean statementBody = node.getBodyKind() == LambdaExpressionTree.BodyKind.STATEMENT;
+        // Also format switch expressions as statement body instead of inlining them
+        boolean statementBody = node.getBodyKind() == LambdaExpressionTree.BodyKind.STATEMENT
+                || node.getBody().getKind() == Kind.SWITCH_EXPRESSION;
         boolean parens = builder.peekToken().equals(Optional.of("("));
         builder.open("lambda arguments", parens ? plusFour : ZERO);
         if (parens) {

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -127,7 +127,6 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.TypeParameterTree;
@@ -1218,9 +1217,12 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     @Override
     public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
         sync(node);
-        // Also format switch expressions as statement body instead of inlining them
-        boolean statementBody = node.getBodyKind() == LambdaExpressionTree.BodyKind.STATEMENT
-                || node.getBody().getKind() == Kind.SWITCH_EXPRESSION;
+        boolean statementBody = node.getBodyKind() == LambdaExpressionTree.BodyKind.STATEMENT;
+        visitLambdaExpression(node, statementBody);
+        return null;
+    }
+
+    protected void visitLambdaExpression(LambdaExpressionTree node, boolean statementBody) {
         boolean parens = builder.peekToken().equals(Optional.of("("));
         builder.open("lambda arguments", parens ? plusFour : ZERO);
         if (parens) {
@@ -1269,7 +1271,6 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             scan(node.getBody(), null);
         }
         builder.close();
-        return null;
     }
 
     @Override

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -232,6 +232,7 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
                 token(">");
                 builder.space();
                 if (node.getBody().getKind() == BLOCK) {
+                    // Explicit call with {@link CollapseEmptyOrNot.YES} to handle empty case blocks.
                     visitBlock(
                             (BlockTree) node.getBody(),
                             CollapseEmptyOrNot.YES,
@@ -248,6 +249,11 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
         return null;
     }
 
+    /**
+     * TODO(fwindheuser): Collapse with
+     * {@link JavaInputAstVisitor#visitLambdaExpression(LambdaExpressionTree, Void)}} after dropping Java 11
+     * compatibility.
+     */
     @Override
     public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
         sync(node);

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -31,8 +31,10 @@ import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.InstanceOfTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.SwitchExpressionTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.YieldTree;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
@@ -243,6 +245,16 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
             default:
                 throw new AssertionError(node.getCaseKind());
         }
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
+        sync(node);
+        // Also format switch expressions as statement body instead of inlining them
+        boolean statementBody = node.getBodyKind() == LambdaExpressionTree.BodyKind.STATEMENT
+                || node.getBody().getKind() == Kind.SWITCH_EXPRESSION;
+        visitLambdaExpression(node, statementBody);
         return null;
     }
 }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -26,6 +26,7 @@ import com.palantir.javaformat.Op;
 import com.palantir.javaformat.OpsBuilder;
 import com.palantir.javaformat.java.JavaInputAstVisitor;
 import com.sun.source.tree.BindingPatternTree;
+import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
@@ -199,15 +200,17 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
         } else {
             token("case", plusTwo);
             builder.space();
+            builder.open(plusTwo);
             boolean first = true;
             for (ExpressionTree expression : node.getExpressions()) {
                 if (!first) {
                     token(",");
-                    builder.space();
+                    builder.breakOp(" ");
                 }
                 scan(expression, null);
                 first = false;
             }
+            builder.close();
         }
         switch (node.getCaseKind()) {
             case STATEMENT:
@@ -226,7 +229,15 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
                 token("-");
                 token(">");
                 builder.space();
-                scan(node.getBody(), null);
+                if (node.getBody().getKind() == BLOCK) {
+                    visitBlock(
+                            (BlockTree) node.getBody(),
+                            CollapseEmptyOrNot.YES,
+                            AllowLeadingBlankLine.NO,
+                            AllowTrailingBlankLine.NO);
+                } else {
+                    scan(node.getBody(), null);
+                }
                 builder.guessToken(";");
                 break;
             default:

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -22,4 +22,25 @@ class ExpressionSwitch {
     };
     return val;
   }
+
+  enum Wrapping {
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+    THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
+  }
+
+  int wrapping(Wrapping w) {
+    switch (w) {
+        case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+            THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+            THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+    }
+  }
+
+  Supplier<Integer> lambda(int k) {
+    return () -> switch (k) {
+      case 0 -> true;
+      default -> false;
+    };
+  }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -23,17 +23,15 @@ class ExpressionSwitch {
     return val;
   }
 
-  enum Wrapping {
-    THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
-    THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
-    THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
-  }
-
   int wrapping(Wrapping w) {
     switch (w) {
         case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
             THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
             THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+    }
+
+    switch (w) {
+        case CASE_A, CASE_B, CASE_C -> {}
     }
   }
 

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
@@ -28,4 +28,25 @@ class ExpressionSwitch {
                 };
         return val;
     }
+
+    enum Wrapping {
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+        THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
+    }
+
+    int wrapping(Wrapping w) {
+        switch (w) {
+            case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+                THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+                THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+        }
+    }
+
+    Supplier<Integer> closeDelimiter(int k) {
+        return () -> switch (k) {
+            case 0 -> true;
+            default -> false;
+        };
+    }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
@@ -29,21 +29,19 @@ class ExpressionSwitch {
         return val;
     }
 
-    enum Wrapping {
-        THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
-        THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
-        THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE,
-    }
-
     int wrapping(Wrapping w) {
         switch (w) {
             case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
                 THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
                 THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
         }
+
+        switch (w) {
+            case CASE_A, CASE_B, CASE_C -> {}
+        }
     }
 
-    Supplier<Integer> closeDelimiter(int k) {
+    Supplier<Integer> lambda(int k) {
         return () -> switch (k) {
             case 0 -> true;
             default -> false;


### PR DESCRIPTION
## Before this PR
Switch expressions were incorrectly formatted in two cases as reported in https://github.com/palantir/palantir-java-format/pull/383:

1. When the switch expression is a lambda body:
```diff
 Supplier<Integer> closeDelimiter(int k) {
     return () -> switch (k) {
         case 0 -> true;
-        default -> false;};
+        default -> false;
+   };
 }
```

2. When multiple case parameters exceed the maximum line length:
```diff
  int wrapping(Wrapping w) {
      switch (w) {
-         case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE, THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO, THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
+         case THIS_IS_A_VERY_LONG_ENUM_VALUE_ONE,
+             THIS_IS_A_VERY_LONG_ENUM_VALUE_TWO,
+             THIS_IS_A_VERY_LONG_ENUM_VALUE_THREE -> {}
      }
  }
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix line breaks in switch expression
==COMMIT_MSG==

cc @pkoenig10 
