### PR TITLE
Fix: Support intellij 212 (2021.2 EAP)

### DIFF
--- a/changelog/@unreleased/pr-502.v2.yml
+++ b/changelog/@unreleased/pr-502.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Support Intellij 212 API level (2021.2 EAP). The type signature changed
+    from `Collection<TextRange>` to `Collection<? extends TextRange>`. This is inspired
+    by same fix in bazel intellij plugin to avoid compiling multiple versions
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/502

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/CodeStyleManagerDecorator.java
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
  *
  * The https://github.com/JetBrains/intellij-community/commit/2d5740176cc9206db2d5ab5d8f67cec74b85a017
  * added a CodeManager#scheduleReformatWhenSettingsComputed(PsiFile) method in idea/202.5103.13 where the
- * default implementation throws an UnsuportedOperationException.
+ * default implementation throws an UnsupportedOperationException.
  * See https://youtrack.jetbrains.com/issue/IDEA-244645 for more details.
  */
 @SuppressWarnings("deprecation")
@@ -93,7 +93,7 @@ class CodeStyleManagerDecorator extends CodeStyleManagerImpl implements Formatti
     }
 
     @Override
-    public void reformatText(PsiFile file, Collection<TextRange> ranges) throws IncorrectOperationException {
+    public void reformatText(PsiFile file, Collection ranges) throws IncorrectOperationException {
         delegate.reformatText(file, ranges);
     }
 
@@ -104,7 +104,7 @@ class CodeStyleManagerDecorator extends CodeStyleManagerImpl implements Formatti
     }
 
     @Override
-    public void reformatTextWithContext(PsiFile file, Collection<TextRange> ranges) throws IncorrectOperationException {
+    public void reformatTextWithContext(PsiFile file, Collection ranges) throws IncorrectOperationException {
         delegate.reformatTextWithContext(file, ranges);
     }
 

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirCodeStyleManager.java
@@ -90,7 +90,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
     }
 
     static Map<TextRange, String> getReplacements(
-            FormatterService formatter, String text, Collection<TextRange> ranges) {
+            FormatterService formatter, String text, Collection<? extends TextRange> ranges) {
         try {
             ImmutableMap.Builder<TextRange, String> replacements = ImmutableMap.builder();
             formatter.getFormatReplacements(text, toRanges(ranges)).forEach(replacement -> {
@@ -103,7 +103,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
         }
     }
 
-    private static Collection<Range<Integer>> toRanges(Collection<TextRange> textRanges) {
+    private static Collection<Range<Integer>> toRanges(Collection<? extends TextRange> textRanges) {
         return textRanges.stream()
                 .map(textRange -> Range.closedOpen(textRange.getStartOffset(), textRange.getEndOffset()))
                 .collect(Collectors.toList());
@@ -125,7 +125,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
     }
 
     @Override
-    public void reformatText(PsiFile file, Collection<TextRange> ranges) throws IncorrectOperationException {
+    public void reformatText(PsiFile file, Collection ranges) throws IncorrectOperationException {
         if (overrideFormatterForFile(file)) {
             formatInternal(file, ranges);
         } else {
@@ -140,7 +140,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
     }
 
     @Override
-    public void reformatTextWithContext(PsiFile file, Collection<TextRange> ranges) {
+    public void reformatTextWithContext(PsiFile file, Collection ranges) {
         if (overrideFormatterForFile(file)) {
             formatInternal(file, ranges);
         } else {
@@ -176,7 +176,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
                 && PalantirJavaFormatSettings.getInstance(getProject()).isEnabled();
     }
 
-    private void formatInternal(PsiFile file, Collection<TextRange> ranges) {
+    private void formatInternal(PsiFile file, Collection<? extends TextRange> ranges) {
         ApplicationManager.getApplication().assertWriteAccessAllowed();
         PsiDocumentManager documentManager = PsiDocumentManager.getInstance(getProject());
         documentManager.commitAllDocuments();
@@ -220,7 +220,7 @@ final class PalantirCodeStyleManager extends CodeStyleManagerDecorator {
      * <p>Overriding methods will need to modify the document with the result of the external formatter (usually using
      * {@link #performReplacements(Document, Map)}.
      */
-    private void format(Document document, Collection<TextRange> ranges) {
+    private void format(Document document, Collection<? extends TextRange> ranges) {
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(getProject());
         FormatterService formatter = implementationCache.get(settings.getImplementationClassPath());
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support Intellij 212 API level (2021.2 EAP). The type signature changed from `Collection<TextRange>` to `Collection<? extends TextRange>`. This is inspired by same fix in bazel intellij plugin to avoid compiling multiple versions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

