### PR TITLE
Improvement: Convert projectComponent to poststartupactivity

### DIFF
--- a/changelog/@unreleased/pr-503.v2.yml
+++ b/changelog/@unreleased/pr-503.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Convert InitialConfigurationComponent from project component to postStartupActivity
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/503

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/InitialConfigurationStartupActivity.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/InitialConfigurationStartupActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,14 @@
 
 package com.palantir.javaformat.intellij;
 
-import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import org.jetbrains.annotations.NotNull;
 
-final class InitialConfigurationComponent implements ProjectComponent {
-    private final PalantirJavaFormatSettings settings;
-
-    public InitialConfigurationComponent(PalantirJavaFormatSettings settings) {
-        this.settings = settings;
-    }
-
+public final class InitialConfigurationStartupActivity implements StartupActivity.DumbAware {
     @Override
-    public void projectOpened() {
+    public void runActivity(@NotNull Project project) {
+        PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         if (settings.isUninitialized()) {
             settings.setEnabled(false);
         }

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,14 +10,6 @@
    -->
   <depends>com.intellij.modules.java</depends>
 
-  <project-components>
-    <component>
-      <implementation-class>
-        com.palantir.javaformat.intellij.InitialConfigurationComponent
-      </implementation-class>
-    </component>
-  </project-components>
-
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable"
                          id="palantir-java-format.settings"
@@ -26,6 +18,7 @@
     <projectService serviceInterface="com.intellij.psi.codeStyle.CodeStyleManager"
                     serviceImplementation="com.palantir.javaformat.intellij.PalantirCodeStyleManager"
                     overrides="true"/>
+    <postStartupActivity implementation="com.palantir.javaformat.intellij.InitialConfigurationStartupActivity"/>
   </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Convert InitialConfigurationComponent from project component to postStartupActivity
==COMMIT_MSG==

When testing on 2021.2 EAP I was getting 
```
2021-07-06 16:07:55,842 [  36659]  ERROR - llij.ide.plugins.PluginManager - Fatal error initializing '
        com.palantir.javaformat.intellij.InitialConfigurationComponent
      ' [Plugin: palantir-java-format]
com.intellij.diagnostic.PluginException: Fatal error initializing '
        com.palantir.javaformat.intellij.InitialConfigurationComponent
      ' [Plugin: palantir-java-format]
        at com.intellij.serviceContainer.ComponentManagerImpl.handleInitComponentError$intellij_platform_serviceContainer(ComponentManagerImpl.kt:515)
        at com.intellij.serviceContainer.ComponentManagerImpl.registerComponents(ComponentManagerImpl.kt:387)
        at com.intellij.serviceContainer.ComponentManagerImpl.access$registerComponents(ComponentManagerImpl.kt:58)
        at com.intellij.serviceContainer.ComponentManagerImpl.registerComponents(ComponentManagerImpl.kt:255)
        at com.intellij.openapi.client.ClientAwareComponentManager.registerComponents(ClientAwareComponentManager.kt:62)
        at com.intellij.openapi.project.impl.ProjectLoadHelper.registerComponents(projectLoader.kt:25)
        at com.intellij.openapi.project.impl.ProjectManagerImpl.initProject(ProjectManagerImpl.java:176)
        at com.intellij.openapi.project.impl.ProjectManagerExImpl.prepareProject(ProjectManagerExImpl.kt:270)
        at com.intellij.openapi.project.impl.ProjectManagerExImpl.access$prepareProject(ProjectManagerExImpl.kt:57)
        at com.intellij.openapi.project.impl.ProjectManagerExImpl$doOpenAsync$1.invoke(ProjectManagerExImpl.kt:119)
        at com.intellij.openapi.project.impl.ProjectManagerExImpl$doOpenAsync$1.invoke(ProjectManagerExImpl.kt:57)
        at com.intellij.openapi.project.impl.ProjectUiFrameAllocator$run$progressRunner$1.apply(ProjectFrameAllocator.kt:94)
        at com.intellij.openapi.project.impl.ProjectUiFrameAllocator$run$progressRunner$1.apply(ProjectFrameAllocator.kt:71)
        at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:243)
        at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:183)
        at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:705)
        at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:647)
        at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:63)
        at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:170)
        at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:243)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1764)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1756)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.ClassNotFoundException:
        com.palantir.javaformat.intellij.InitialConfigurationComponent
       PluginClassLoader(plugin=PluginDescriptor(name=palantir-java-format, id=palantir-java-format, descriptorPath=plugin.xml, path=/Volumes/git/palantir-java-format/idea-plugin/build/idea-sandbox/plugins/palantir-java-format, version=2.1.0.dirty, package=null), packagePrefix=null, instanceId=49, state=active)
        at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.java:254)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at com.intellij.serviceContainer.ComponentManagerImpl.registerComponent(ComponentManagerImpl.kt:441)
        at com.intellij.serviceContainer.ComponentManagerImpl.registerComponents(ComponentManagerImpl.kt:380)
        ... 25 more
```
which made no sense to me but sincce project components are deprecated instead of inevstigating this further and figuring out a workaround I converted the logic to startupactivity and everything seems to be working fine.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

