### PR TITLE
Fix java 16 compatibility

### DIFF
--- a/changelog/@unreleased/pr-559.v2.yml
+++ b/changelog/@unreleased/pr-559.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix java 16 compatibility
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/559

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/Utils.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/Utils.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.List;
 
 public final class Utils {
-
     private Utils() {}
 
     public static String applyReplacements(String input, Collection<Replacement> replacementsCollection) {

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
@@ -125,8 +125,24 @@ class JavacTokens {
 
         @Override
         protected Comment processComment(int pos, int endPos, CommentStyle style) {
-            char[] buf = reader.getRawCharacters(pos, endPos);
+            char[] buf = getRawCharactersReflectively(pos, endPos);
             return new CommentWithTextAndPosition(pos, endPos, new AccessibleReader(fac, buf, buf.length), style);
+        }
+
+        private char[] getRawCharactersReflectively(int beginIndex, int endIndex) {
+            Object instance;
+            try {
+                instance = JavaTokenizer.class.getDeclaredField("reader").get(this);
+            } catch (ReflectiveOperationException e) {
+                instance = this;
+            }
+            try {
+                return (char[]) instance.getClass()
+                        .getMethod("getRawCharacters", int.class, int.class)
+                        .invoke(instance, beginIndex, endIndex);
+            } catch (ReflectiveOperationException e) {
+                throw new LinkageError(e.getMessage(), e);
+            }
         }
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -35,12 +35,14 @@ import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.SwitchExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.YieldTree;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeInfo;
 import java.util.List;
 import java.util.Optional;
+import javax.lang.model.element.Name;
 
 /**
  * Extends {@link JavaInputAstVisitor} with support for AST nodes that were added or modified for Java 14.
@@ -54,10 +56,27 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
     @Override
     public Void visitBindingPattern(BindingPatternTree node, Void unused) {
         sync(node);
-        scan(node.getType(), null);
-        builder.breakOp(" ");
-        visit(node.getBinding());
+        try {
+            VariableTree variableTree = (VariableTree)
+                    BindingPatternTree.class.getMethod("getVariable").invoke(node);
+            visitBindingPattern(variableTree.getType(), variableTree.getName());
+        } catch (ReflectiveOperationException e1) {
+            try {
+                Tree type = (Tree) BindingPatternTree.class.getMethod("getType").invoke(node);
+                Name name = (Name) BindingPatternTree.class.getMethod("getName").invoke(node);
+                visitBindingPattern(type, name);
+            } catch (ReflectiveOperationException e2) {
+                e2.addSuppressed(e1);
+                throw new LinkageError(e2.getMessage(), e2);
+            }
+        }
         return null;
+    }
+
+    private void visitBindingPattern(Tree type, Name name) {
+        scan(type, null);
+        builder.breakOp(" ");
+        visit(name);
     }
 
     @Override

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/DiagnosticTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/DiagnosticTest.java
@@ -94,7 +94,7 @@ public class DiagnosticTest {
 
         int result = main.format(path.toString());
         assertThat(stdout.toString()).isEmpty();
-        assertThat(stderr.toString()).contains("InvalidSyntax.java:1:35: error: illegal unicode escape");
+        assertThat(stderr.toString()).contains("error: illegal unicode escape");
         assertThat(result).isEqualTo(1);
     }
 


### PR DESCRIPTION
## Before this PR
The formatter would fail when ran with Java 16+ with:

```
java.lang.NoSuchFieldError: reader
        at com.palantir.javaformat.java.JavacTokens$CommentSavingTokenizer.processComment(JavacTokens.java:128)
        at jdk.compiler/com.sun.tools.javac.parser.JavaTokenizer.readToken(JavaTokenizer.java:958)
        at jdk.compiler/com.sun.tools.javac.parser.Scanner.nextToken(Scanner.java:115)
        at com.palantir.javaformat.java.JavacTokens.getTokens(JavacTokens.java:86)
        at com.palantir.javaformat.java.JavaInput.buildToks(JavaInput.java:365)
        at com.palantir.javaformat.java.JavaInput.buildToks(JavaInput.java:334)
        at com.palantir.javaformat.java.JavaInput.<init>(JavaInput.java:272)
        at com.palantir.javaformat.java.Formatter.getFormatReplacements(Formatter.java:297)
        at com.palantir.javaformat.java.Formatter.formatSource(Formatter.java:284)
        at com.palantir.javaformat.java.FormatFileCallable.call(FormatFileCallable.java:42)
        at com.palantir.javaformat.java.FormatFileCallable.call(FormatFileCallable.java:24)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

## After this PR

This PR cherry-picks the following commit from google-java-format which adds a fix for Java 16 incompatibilities:
* Original commit: https://github.com/google/google-java-format/commit/0a2f8647929e361304db5d1360896152e76a7e21
* Original commit message:
    ```
    * Work around change to tokenization in JDK-8254073
    * Access refactored expression pattern getters reflectively
    * Relax a check on a diagnostic whose position changed
    ```

==COMMIT_MSG==
Fix java 16 compatibility
==COMMIT_MSG==

Flup is to test on CI using Java 17. But verified locally and could format files using a jar that is build and run with jdk17.
