### PR TITLE
Enable bootstrapping formatter on java 15+

### DIFF
--- a/changelog/@unreleased/pr-580.v2.yml
+++ b/changelog/@unreleased/pr-580.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable bootstrapping formatter on java 15+
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/580


### PR DESCRIPTION
## Before this PR
FLUP on https://github.com/palantir/palantir-java-format/pull/562

In order to gradually move into the new bootstrapping formatter codepath, we just enabled it for projects using Java 16+. However projects using Java 15 might already want to use new language features and would benefit from formatting in the IDE.

## After this PR

* Use bootstrapping formatter when using java 15+ as project SDK.
* Use jdk major version as cache key to update the formatter version when the jdk major version changes.

==COMMIT_MSG==
Enable bootstrapping formatter on java 15+
==COMMIT_MSG==