### PR TITLE
Revert using bootstrapping formatter for Java 15

### DIFF
--- a/changelog/@unreleased/pr-582.v2.yml
+++ b/changelog/@unreleased/pr-582.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Revert using bootstrapping formatter for Java 15
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/582

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -23,7 +23,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JdkUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ProjectRootManager;
-import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.logsafe.Preconditions;
 import java.io.IOException;
@@ -63,12 +62,14 @@ final class FormatterProvider {
         List<Path> implementationClasspath =
                 getImplementationUrls(cacheKey.implementationClassPath, cacheKey.useBundledImplementation);
 
+        // TODO(fwindheuser): Temporarily disable the bootstrapping formatter to debug it crashing intellij on
+        //  certain files
         // Enable the bootstrapping formatter for projects using Java 15+ as they might use new language features.
-        if (jdkMajorVersion >= 15) {
-            Path jdkPath = getJdkPath(cacheKey.project);
-            log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
-            return new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath);
-        }
+        // if (jdkMajorVersion >= 15) {
+        //     Path jdkPath = getJdkPath(cacheKey.project);
+        //     log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
+        //     return new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath);
+        // }
 
         // Use "in-process" formatter service
         log.info("Using in-process formatter for jdk version {}", jdkMajorVersion);


### PR DESCRIPTION
## Before this PR
Revert: https://github.com/palantir/palantir-java-format/pull/580

The bootstrapping formatter can crash intellij on certain input files. Disabling to get a new stable version out while investigating.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Revert using bootstrapping formatter for Java 15
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

