### PR TITLE
Fix deadlock trying to format large input

### DIFF
--- a/changelog/@unreleased/pr-583.v2.yml
+++ b/changelog/@unreleased/pr-583.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix deadlock trying to format large input
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/583

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JdkUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.logsafe.Preconditions;
 import java.io.IOException;
@@ -62,14 +63,12 @@ final class FormatterProvider {
         List<Path> implementationClasspath =
                 getImplementationUrls(cacheKey.implementationClassPath, cacheKey.useBundledImplementation);
 
-        // TODO(fwindheuser): Temporarily disable the bootstrapping formatter to debug it crashing intellij on
-        //  certain files
         // Enable the bootstrapping formatter for projects using Java 15+ as they might use new language features.
-        // if (jdkMajorVersion >= 15) {
-        //     Path jdkPath = getJdkPath(cacheKey.project);
-        //     log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
-        //     return new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath);
-        // }
+        if (jdkMajorVersion >= 15) {
+            Path jdkPath = getJdkPath(cacheKey.project);
+            log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
+            return new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath);
+        }
 
         // Use "in-process" formatter service
         log.info("Using in-process formatter for jdk version {}", jdkMajorVersion);

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
@@ -34,13 +34,14 @@ final class FormatterCommandRunner {
             outputStream.write(input.getBytes(StandardCharsets.UTF_8));
         }
 
+        // Make sure to drain stdout before waiting for the process to exit as this can result in a deadlock otherwise.
+        String stdout = readToString(process.getInputStream());
+
         try {
             process.waitFor();
         } catch (InterruptedException e) {
             throw new RuntimeException("Interrupted while executing command", e);
         }
-
-        String stdout = readToString(process.getInputStream());
 
         if (process.exitValue() != 0) {
             String stderr = readToString(process.getErrorStream());

--- a/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterServiceTest.java
+++ b/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterServiceTest.java
@@ -54,6 +54,22 @@ final class BootstrappingFormatterServiceTest {
         assertThat(formatted).isEqualTo(expectedOutput);
     }
 
+    @Test
+    void can_format_large_input_file() {
+        String input = "class A {\n"
+                + "  void f(){\n"
+                + "    System.out.println(\"Test output\");\n".repeat(2000)
+                + "  }\n"
+                + "}\n";
+
+        ImmutableList<Replacement> replacements =
+                getFormatter().getFormatReplacements(input, List.of(Range.open(0, input.length())));
+
+        assertThat(replacements).singleElement().satisfies(replacement -> {
+            assertThat(replacement.getReplacementString()).startsWith("class A {\n    void f() {");
+        });
+    }
+
     private BootstrappingFormatterService getFormatter() {
         return new BootstrappingFormatterService(
                 javaBinPath(), Runtime.version().feature(), getClasspath());


### PR DESCRIPTION
## Before this PR
FLUP on https://github.com/palantir/palantir-java-format/pull/582

We had a bug that would result in a deadlock when trying to format large input files using the bootstrapping formatter.

We would wait for the process to finish before draining stdout. For large inputs, this can result in the situation where the process is waiting for availability to write more data to stdout while we wait for the process to finish before draining stdout and providing new availability. As a result the process would indefinitely hang and e.g. freeze Intellij.

## After this PR

Make sure to consume the stdout before waiting for the process to finish.

==COMMIT_MSG==
Fix deadlock trying to format large input
==COMMIT_MSG==
