### PR TITLE
PJF plugin supports the new `PLUGIN_DIR/lib/*.jar` structure

### DIFF
--- a/changelog/@unreleased/pr-617.v2.yml
+++ b/changelog/@unreleased/pr-617.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: palantir-java-format intellij plugin supports the new `PLUGIN_DIR/lib/*.jar`
     structure in addition to the old `PLUGIN_DIR/impl/*.jar` location
   links:

--- a/changelog/@unreleased/pr-617.v2.yml
+++ b/changelog/@unreleased/pr-617.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: palantir-java-format intellij plugin supports the new `PLUGIN_DIR/lib/*.jar`
+    structure in addition to the old `PLUGIN_DIR/impl/*.jar` location
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/617

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -83,9 +83,13 @@ final class FormatterProvider {
 
     private static List<Path> getBundledImplementationUrls() {
         // Load from the jars bundled with the plugin.
-        Path implDir = PalantirCodeStyleManager.PLUGIN.getPath().toPath().resolve("impl");
-        log.debug("Using palantir-java-format implementation bundled with plugin: {}", implDir);
-        return listDirAsUrlsUnchecked(implDir);
+        Path pluginPath = PalantirCodeStyleManager.PLUGIN.getPluginPath();
+        Path implDir = pluginPath.resolve("impl");
+        // Directory appears to have been renamed from 'impl' to 'lib' in recent idea releases
+        Path pathToUse = Files.isDirectory(implDir) ? implDir : pluginPath.resolve("lib");
+
+        log.debug("Using palantir-java-format implementation bundled with plugin: {}", pathToUse);
+        return listDirAsUrlsUnchecked(pathToUse);
     }
 
     private static List<Path> getImplementationUrls(


### PR DESCRIPTION
previous intellij versions used `PLUGIN_DIR/impl/*.jar`

## Before this PR
```
Caused by: java.lang.RuntimeException: Couldn't list dir: /home/ckozak/.local/share/JetBrains/IntelliJIdea2021.3/palantir-java-format/impl
	at com.palantir.javaformat.intellij.FormatterProvider.listDirAsUrlsUnchecked(FormatterProvider.java:159)
	at com.palantir.javaformat.intellij.FormatterProvider.getBundledImplementationUrls(FormatterProvider.java:88)
	at com.palantir.javaformat.intellij.FormatterProvider.getImplementationUrls(FormatterProvider.java:95)
	at com.palantir.javaformat.intellij.FormatterProvider.createFormatter(FormatterProvider.java:64)
	at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$3(LocalLoadingCache.java:197)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$13(BoundedLocalCache.java:2451)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1908)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2449)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2432)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:107)
	at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:57)
	at com.palantir.javaformat.intellij.FormatterProvider.get(FormatterProvider.java:54)
	at com.palantir.javaformat.intellij.PalantirCodeStyleManager.format(PalantirCodeStyleManager.java:195)
	at com.palantir.javaformat.intellij.PalantirCodeStyleManager.formatInternal(PalantirCodeStyleManager.java:184)
	at com.palantir.javaformat.intellij.PalantirCodeStyleManager.reformatText(PalantirCodeStyleManager.java:118)
	at com.intellij.codeInsight.actions.ReformatCodeProcessor.lambda$doReformat$5(ReformatCodeProcessor.java:196)
	at com.intellij.util.SlowOperations.allowSlowOperations(SlowOperations.java:147)
	at com.intellij.codeInsight.actions.ReformatCodeProcessor.lambda$doReformat$6(ReformatCodeProcessor.java:186)
	at com.intellij.openapi.editor.ex.util.EditorScrollingPositionKeeper.perform(EditorScrollingPositionKeeper.java:100)
	at com.intellij.codeInsight.actions.ReformatCodeProcessor.doReformat(ReformatCodeProcessor.java:186)
	at com.intellij.codeInsight.actions.ReformatCodeProcessor.lambda$prepareTask$2(ReformatCodeProcessor.java:134)
	at com.intellij.application.options.CodeStyle.doWithTemporarySettings(CodeStyle.java:338)
	at com.intellij.codeInsight.actions.ReformatCodeProcessor.lambda$prepareTask$3(ReformatCodeProcessor.java:130)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor$ProcessingTask.lambda$performFileProcessing$5(AbstractLayoutCodeProcessor.java:441)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$doRunWriteCommandAction$1(WriteCommandAction.java:150)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:947)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.lambda$doRunWriteCommandAction$2(WriteCommandAction.java:148)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:210)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:184)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.doRunWriteCommandAction(WriteCommandAction.java:157)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.run(WriteCommandAction.java:124)
	at com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor$ProcessingTask.lambda$performFileProcessing$6(AbstractLayoutCodeProcessor.java:441)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:437)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:455)
	at com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor$ProcessingTask.performFileProcessing(AbstractLayoutCodeProcessor.java:436)
	... 99 more
Caused by: java.nio.file.NoSuchFileException: /home/ckozak/.local/share/JetBrains/IntelliJIdea2021.3/palantir-java-format/impl
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:432)
	at java.base/java.nio.file.Files.newDirectoryStream(Files.java:472)
	at java.base/java.nio.file.Files.list(Files.java:3774)
	at com.palantir.javaformat.intellij.FormatterProvider.listDirAsUrlsUnchecked(FormatterProvider.java:156)
	... 134 more
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
palantir-java-format intellij plugin supports the new `PLUGIN_DIR/lib/*.jar` structure in addition to the old `PLUGIN_DIR/impl/*.jar` location
==COMMIT_MSG==

## Possible downsides?
Hard to test.
