### PR TITLE
remove the filer for jdk17

### DIFF
--- a/changelog/@unreleased/pr-620.v2.yml
+++ b/changelog/@unreleased/pr-620.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix Idea plugin regression self-bootstrapping for jdk17
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/620

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -75,7 +75,9 @@ tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask) {
 
     // Also pack the formatter in its own directory
     into("${name}/impl") {
-        from configurations.formatter.filter { !configurations.runtimeClasspath.contains(it) }
+        // Note that we don't filter down the jars in the impl directory due to behavior when
+        // the formatter is bootstrapped with jdk16+ exports.
+        from configurations.formatter
     }
 }
 


### PR DESCRIPTION
==COMMIT_MSG==
Fix Idea plugin regression self-bootstrapping for jdk17
==COMMIT_MSG==
