### PR TITLE
Handle empty format response replacements

### DIFF
--- a/changelog/@unreleased/pr-622.v2.yml
+++ b/changelog/@unreleased/pr-622.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle empty format response replacements
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/622

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -81,7 +81,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .build();
 
         Optional<String> output = FormatterCommandRunner.runWithStdin(command.toArgs(), input);
-        if (output.isEmpty()) {
+        if (output.isEmpty() || output.get().isEmpty()) {
             return ImmutableList.of();
         }
         return MAPPER.readValue(output.get(), new TypeReference<>() {});


### PR DESCRIPTION
## Before this PR
#621 BootstrappingFormatterService.getFormatReplacementsInternal fails on empty response
```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (String)""; line: 1, column: 0]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4624)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4469)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3434)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3417)
	at com.palantir.javaformat.bootstrap.BootstrappingFormatterService.getFormatReplacementsInternal(BootstrappingFormatterService.java:87)
	at com.palantir.javaformat.bootstrap.BootstrappingFormatterService.getFormatReplacements(BootstrappingFormatterService.java:56)
```

## After this PR
==COMMIT_MSG==
Handle empty format response replacements
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

