### PR TITLE
Handle empty implementation version

### DIFF
--- a/changelog/@unreleased/pr-644.v2.yml
+++ b/changelog/@unreleased/pr-644.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle empty implementation version
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/644

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.java
@@ -97,7 +97,7 @@ class PalantirJavaFormatConfigurable extends BaseConfigurable implements Searcha
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         enable.setSelected(settings.isEnabled());
         styleComboBox.setSelectedItem(UiFormatterStyle.convert(settings.getStyle()));
-        pluginVersion.setText(settings.getImplementationVersion());
+        pluginVersion.setText(settings.getImplementationVersion().orElse("unknown"));
         formatterVersion.setText(getFormatterVersionText(settings));
     }
 

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -90,13 +90,10 @@ class PalantirJavaFormatSettings implements PersistentStateComponent<PalantirJav
 
     boolean injectedVersionIsOutdated() {
         Optional<String> formatterVersion = computeFormatterVersion();
-        if (formatterVersion.isEmpty()) {
-            return true;
-        }
+        Optional<OrderableSlsVersion> implementationVersion = OrderableSlsVersion.safeValueOf(
+                getImplementationVersion().map(v -> v.replace(".dirty", "")).orElse(""));
 
-        Optional<OrderableSlsVersion> implementationVersion =
-                OrderableSlsVersion.safeValueOf(getImplementationVersion().replace(".dirty", ""));
-        if (implementationVersion.isEmpty()) {
+        if (formatterVersion.isEmpty() || implementationVersion.isEmpty()) {
             return true;
         }
 
@@ -104,9 +101,9 @@ class PalantirJavaFormatSettings implements PersistentStateComponent<PalantirJav
         return injectedVersion.compareTo(implementationVersion.get()) < 0;
     }
 
-    String getImplementationVersion() {
-        return Strings.nullToEmpty(
-                PalantirJavaFormatConfigurable.class.getPackage().getImplementationVersion());
+    Optional<String> getImplementationVersion() {
+        return Optional.ofNullable(Strings.emptyToNull(
+                PalantirJavaFormatConfigurable.class.getPackage().getImplementationVersion()));
     }
 
     Optional<String> computeFormatterVersion() {
@@ -132,7 +129,7 @@ class PalantirJavaFormatSettings implements PersistentStateComponent<PalantirJav
     enum EnabledState {
         UNKNOWN,
         ENABLED,
-        DISABLED;
+        DISABLED
     }
 
     static class State {

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -16,6 +16,7 @@
 
 package com.palantir.javaformat.intellij;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
@@ -93,15 +94,19 @@ class PalantirJavaFormatSettings implements PersistentStateComponent<PalantirJav
             return true;
         }
 
-        OrderableSlsVersion implementationVersion =
-                OrderableSlsVersion.valueOf(getImplementationVersion().replace(".dirty", ""));
-        OrderableSlsVersion injectedVersion = OrderableSlsVersion.valueOf(formatterVersion.get());
+        Optional<OrderableSlsVersion> implementationVersion =
+                OrderableSlsVersion.safeValueOf(getImplementationVersion().replace(".dirty", ""));
+        if (implementationVersion.isEmpty()) {
+            return true;
+        }
 
-        return injectedVersion.compareTo(implementationVersion) < 0;
+        OrderableSlsVersion injectedVersion = OrderableSlsVersion.valueOf(formatterVersion.get());
+        return injectedVersion.compareTo(implementationVersion.get()) < 0;
     }
 
     String getImplementationVersion() {
-        return PalantirJavaFormatConfigurable.class.getPackage().getImplementationVersion();
+        return Strings.nullToEmpty(
+                PalantirJavaFormatConfigurable.class.getPackage().getImplementationVersion());
     }
 
     Optional<String> computeFormatterVersion() {


### PR DESCRIPTION
## Before this PR
From #643, encountered `NullPointerException` in `PalantirJavaFormatSettings.injectedVersionIsOutdated` below on IntelliJ IDEA 2022.1 EAP (`#IC-221.3427.89`) with palantir-java-format (2.16.0)

```
java.lang.NullPointerException
  at com.palantir.javaformat.intellij.PalantirJavaFormatSettings.injectedVersionIsOutdated(PalantirJavaFormatSettings.java:97)
  at com.palantir.javaformat.intellij.FormatterProvider.get(FormatterProvider.java:58)
  at com.palantir.javaformat.intellij.PalantirCodeStyleManager.format(PalantirCodeStyleManager.java:196)
  at com.palantir.javaformat.intellij.PalantirCodeStyleManager.formatInternal(PalantirCodeStyleManager.java:185)
  at com.palantir.javaformat.intellij.PalantirCodeStyleManager.reformatText(PalantirCodeStyleManager.java:110)
  at com.intellij.codeInsight.editorActions.smartEnter.SmartEnterProcessor.reformat(SmartEnterProcessor.java:38)
```

## After this PR
Fixes #643 

==COMMIT_MSG==
Handle empty implementation version
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

