### PR TITLE
Handle non-sealed modifier

### DIFF
--- a/changelog/@unreleased/pr-671.v2.yml
+++ b/changelog/@unreleased/pr-671.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle non-sealed modifier
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/671

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -2255,7 +2255,12 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 builder.addAll(breakFillList(Optional.empty()));
             }
             if (nextIsModifier()) {
-                token(builder.peekToken().get());
+                String currentToken = builder.peekToken().get();
+                token(currentToken);
+                if (currentToken.equals("non")) {
+                    token(builder.peekToken().get());
+                    token(builder.peekToken().get());
+                }
             } else {
                 scan(annotations.removeFirst(), null);
                 lastWasAnnotation = true;
@@ -2281,7 +2286,8 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             case "strictfp":
             case "default":
             case "sealed":
-            case "non-sealed":
+            case "non":
+            case "-":
                 return true;
             default:
                 return false;

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
@@ -49,7 +49,7 @@ public final class FileBasedTests {
                     .putAll(14, "Records", "RSL", "Var", "ExpressionSwitch", "I574", "I594")
                     .putAll(15, "I603")
                     .putAll(16, "I588")
-                    .putAll(17, "I683", "I684")
+                    .putAll(17, "I683", "I684", "I696")
                     .build();
 
     private final Class<?> testClass;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I696.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I696.input
@@ -1,0 +1,11 @@
+public abstract non-sealed class A extends SealedClass {
+}
+
+non-sealed class B extends SealedClass {
+}
+
+non-sealed @A class B extends SealedClass {
+}
+
+@A non-sealed class B extends SealedClass {
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I696.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I696.output
@@ -1,0 +1,8 @@
+public abstract non-sealed class A extends SealedClass {}
+
+non-sealed class B extends SealedClass {}
+
+non-sealed @A class B extends SealedClass {}
+
+@A
+non-sealed class B extends SealedClass {}


### PR DESCRIPTION
Formatter crashed when encountering non-sealed modifiers.

Bug was also present in google-java-format.

See:
https://github.com/google/google-java-format/issues/696
https://github.com/google/google-java-format/commit/621fb85a8de8000fd80ced515828789cc45ff037

