### PR TITLE
Break on lambda argument in method chain

### DIFF
--- a/changelog/@unreleased/pr-707.v2.yml
+++ b/changelog/@unreleased/pr-707.v2.yml
@@ -1,0 +1,16 @@
+type: improvement
+improvement:
+  description: "Break on lambda argument in method chain\n\n## Before this PR\nChained
+    calls involving lambda expressions don't line break, which conflicts with checkstyle
+    (at least the gradle-baseline checkstyle config)\n\n```java\nclass PalantirLambdaInliningPrefersBreak
+    {\n    void foo() {\n        return hello.read(txn -> {\n                    doSomeWork();\n
+    \                   doSomeMoreWork();\n                })\n                .chainedCall(()
+    -> {\n                    doSomeWork();\n                });\n    }\n}\n\n```\n\n##
+    After this PR\n\n```java\nclass PalantirLambdaInliningPrefersBreak {\n    void
+    foo() {\n        return hello\n                .read(txn -> {\n                    doSomeWork();\n
+    \                   doSomeMoreWork();\n                })\n                .chainedCall(()
+    -> {\n                    doSomeWork();\n                });\n    }\n}\n```\n\n##
+    Possible downsides?\n\U0001F937‍♂️  I've also added a test to show that non-chained
+    lambda calls don't include a line break"
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/707

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -2817,8 +2817,8 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         if (!e.getKind().equals(METHOD_INVOCATION)) {
             return false;
         }
-        return ((MethodInvocationTree) e).getArguments().stream()
-                .anyMatch(argExpr -> argExpr.getKind().equals(LAMBDA_EXPRESSION));
+        return ((MethodInvocationTree) e)
+                .getArguments().stream().anyMatch(argExpr -> argExpr.getKind().equals(LAMBDA_EXPRESSION));
     }
 
     // avoid formattings like:

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.input
@@ -1,0 +1,8 @@
+class PalantirLambdaInliningPrefersBreak {
+    void foo() {
+        return hello.read(txn -> {
+                    doSomeWork();
+                    doSomeMoreWork();
+                });
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.input
@@ -1,4 +1,4 @@
-class PalantirLambdaInliningPrefersBreak {
+class PalantirLambdaBreakChain {
     void foo() {
         return hello.read(txn -> {
                     doSomeWork();

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.output
@@ -1,4 +1,4 @@
-class PalantirLambdaInliningPrefersBreak {
+class PalantirLambdaBreakChain {
     void foo() {
         return hello.read(txn -> {
             doSomeWork();

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg-no-chain.output
@@ -1,0 +1,8 @@
+class PalantirLambdaInliningPrefersBreak {
+    void foo() {
+        return hello.read(txn -> {
+            doSomeWork();
+            doSomeMoreWork();
+        });
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.input
@@ -1,4 +1,4 @@
-class PalantirLambdaInliningPrefersBreak {
+class PalantirLambdaBreakChain {
     void foo() {
         return hello.read(txn -> {
                     doSomeWork();

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.input
@@ -1,0 +1,11 @@
+class PalantirLambdaInliningPrefersBreak {
+    void foo() {
+        return hello.read(txn -> {
+                    doSomeWork();
+                    doSomeMoreWork();
+                })
+                .chainedCall(() -> {
+                    doSomeWork();
+                });
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
@@ -1,0 +1,12 @@
+class PalantirLambdaInliningPrefersBreak {
+    void foo() {
+        return hello
+                .read(txn -> {
+                    doSomeWork();
+                    doSomeMoreWork();
+                })
+                .chainedCall(() -> {
+                    doSomeWork();
+                });
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
@@ -1,4 +1,4 @@
-class PalantirLambdaInliningPrefersBreak {
+class PalantirLambdaBreakChain {
     void foo() {
         return hello
                 .read(txn -> {


### PR DESCRIPTION
## Before this PR
Chained calls involving lambda expressions don't line break, which conflicts with checkstyle (at least the gradle-baseline checkstyle config)

```java
class PalantirLambdaInliningPrefersBreak {
    void foo() {
        return hello.read(txn -> {
                    doSomeWork();
                    doSomeMoreWork();
                })
                .chainedCall(() -> {
                    doSomeWork();
                });
    }
}

```

## After this PR

```java
class PalantirLambdaInliningPrefersBreak {
    void foo() {
        return hello
                .read(txn -> {
                    doSomeWork();
                    doSomeMoreWork();
                })
                .chainedCall(() -> {
                    doSomeWork();
                });
    }
}
```

## Possible downsides?
🤷‍♂️  I've also added a test to show that non-chained lambda calls don't include a line break
