### PR TITLE
Fix lambda compactness regression

### DIFF
--- a/changelog/@unreleased/pr-728.v2.yml
+++ b/changelog/@unreleased/pr-728.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix lambda compactness regression
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/728

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/palantir-break-lambda-arg.output
@@ -1,7 +1,6 @@
 class PalantirLambdaBreakChain {
     void foo() {
-        return hello
-                .read(txn -> {
+        return hello.read(txn -> {
                     doSomeWork();
                     doSomeMoreWork();
                 })


### PR DESCRIPTION
This reverts #708 and #707 which made expression lambdas less
readable.

==COMMIT_MSG==
Fix lambda compactness regression
==COMMIT_MSG==
