### PR TITLE
fix: problems on windows

### DIFF
--- a/changelog/@unreleased/pr-772.v2.yml
+++ b/changelog/@unreleased/pr-772.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix problems on windows
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/772

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JdkUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.SystemInfo;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.logsafe.Preconditions;
@@ -109,7 +110,7 @@ final class FormatterProvider {
         return getProjectJdk(project)
                 .map(Sdk::getHomePath)
                 .map(Path::of)
-                .map(sdkHome -> sdkHome.resolve("bin").resolve("java"))
+                .map(sdkHome -> sdkHome.resolve("bin").resolve("java" + (SystemInfo.isWindows ? ".exe" : "")))
                 .filter(Files::exists)
                 .orElseThrow(() -> new IllegalStateException("Could not determine jdk path for project " + project));
     }

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -127,7 +127,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                             "-cp",
                             implementationClasspath().stream()
                                     .map(path -> path.toAbsolutePath().toString())
-                                    .collect(Collectors.joining(":")))
+                                    .collect(Collectors.joining(System.getProperty("path.separator"))))
                     .add(FORMATTER_MAIN_CLASS);
 
             if (!characterRanges().isEmpty()) {

--- a/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterServiceTest.java
+++ b/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterServiceTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -96,6 +97,10 @@ final class BootstrappingFormatterServiceTest {
 
     private static Path javaBinPath() {
         String javaHome = Preconditions.checkNotNull(System.getProperty("java.home"), "java.home property not set");
-        return Path.of(javaHome).resolve("bin").resolve("java");
+        return Path.of(javaHome).resolve("bin").resolve("java" + (isWindows() ? ".exe" : ""));
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
     }
 }


### PR DESCRIPTION
## Before this PR
idea-plugin was throwing exceptions about project jdk path not being determined.

## After this PR
==COMMIT_MSG==
use correct executable suffix `.exe` while searching for java executable and correct classpath separator `;` on windows.
==COMMIT_MSG==

## Possible downsides?
not aware of any.

fixes #721.