### PR TITLE
Support ea versions of Java

### DIFF
--- a/changelog/@unreleased/pr-784.v2.yml
+++ b/changelog/@unreleased/pr-784.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support ea versions of Java
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/784

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     }
 
     formatter project(':palantir-java-format')
+
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -28,9 +28,6 @@ import com.intellij.openapi.util.SystemInfo;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.logsafe.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -45,6 +42,8 @@ import java.util.ServiceLoader;
 import java.util.jar.Attributes.Name;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class FormatterProvider {
     private static final Logger log = LoggerFactory.getLogger(FormatterProvider.class);

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -18,6 +18,7 @@ package com.palantir.javaformat.intellij;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JdkUtil;
@@ -27,6 +28,9 @@ import com.intellij.openapi.util.SystemInfo;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.logsafe.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -41,8 +45,6 @@ import java.util.ServiceLoader;
 import java.util.jar.Attributes.Name;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class FormatterProvider {
     private static final Logger log = LoggerFactory.getLogger(FormatterProvider.class);
@@ -126,9 +128,15 @@ final class FormatterProvider {
         // or 'openjdk version "15.0.2"'.
         String version = Preconditions.checkNotNull(
                 JdkUtil.getJdkMainAttribute(sdk, Name.IMPLEMENTATION_VERSION), "JDK version is null");
+        return parseSdkJavaVersion(version);
+    }
+
+    @VisibleForTesting
+    static Integer parseSdkJavaVersion(String version) {
         int indexOfVersionDelimiter = version.indexOf('.');
         String normalizedVersion =
                 indexOfVersionDelimiter >= 0 ? version.substring(0, indexOfVersionDelimiter) : version;
+        normalizedVersion = normalizedVersion.replaceAll("-ea", "");
         try {
             return Integer.parseInt(normalizedVersion);
         } catch (NumberFormatException e) {

--- a/idea-plugin/src/test/java/com/palantir/javaformat/intellij/FormatterProviderTest.java
+++ b/idea-plugin/src/test/java/com/palantir/javaformat/intellij/FormatterProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.javaformat.intellij;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/idea-plugin/src/test/java/com/palantir/javaformat/intellij/FormatterProviderTest.java
+++ b/idea-plugin/src/test/java/com/palantir/javaformat/intellij/FormatterProviderTest.java
@@ -1,0 +1,23 @@
+package com.palantir.javaformat.intellij;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public final class FormatterProviderTest {
+
+    @Test
+    void testParseSdkJavaVersion_major() {
+        assertThat(FormatterProvider.parseSdkJavaVersion("15")).isEqualTo(15);
+    }
+
+    @Test
+    void testParseSdkJavaVersion_majorMinorPatch() {
+        assertThat(FormatterProvider.parseSdkJavaVersion("15.0.2")).isEqualTo(15);
+    }
+
+    @Test
+    void testParseSdkJavaVersion_ea() {
+        assertThat(FormatterProvider.parseSdkJavaVersion("15-ea")).isEqualTo(15);
+    }
+}


### PR DESCRIPTION
I received the error message:

```
Could not parse sdk version: 19-ea

java.lang.NumberFormatException: For input string: "19-ea"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:668)
	at java.base/java.lang.Integer.parseInt(Integer.java:786)
	at com.palantir.javaformat.intellij.FormatterProvider.parseSdkJavaVersion(FormatterProvider.java:133)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.palantir.javaformat.intellij.FormatterProvider.getSdkVersion(FormatterProvider.java:120)
	at com.palantir.javaformat.intellij.FormatterProvider.get(FormatterProvider.java:57)
```

and this seems like it'll fix that.
