### PR TITLE
Use bootstrapping formatter starting from Intellij 2022.2

### DIFF
--- a/changelog/@unreleased/pr-798.v2.yml
+++ b/changelog/@unreleased/pr-798.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use bootstrapping formatter starting from Intellij 2022.2
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/798


### PR DESCRIPTION
## Before this PR

Starting with version 2022.2, Intellij now runs with JDK 17 ([release notes](https://blog.jetbrains.com/idea/2022/05/intellij-idea-2022-2-eap-1/#JetBrains_Runtime)). This breaks the formatter because when running with JDK 15+, it requires respective `--add-export` args to be set.

The current workaround is to manually add the missing `--add-export` flags to the Intellij runtime JDK (see this related issue: https://github.com/google/google-java-format/issues/787#issuecomment-1198252984).


## After this PR

To avoid having to manually add the `--add-export` flags to the Intellij runtime JDK, we always use the bootstrapping formatter when running with Intellij 2022.2 or higher.

==COMMIT_MSG==
Use bootstrapping formatter starting from Intellij 2022.2
==COMMIT_MSG==

## Possible downsides?
Running the bootstrapping formatter adds some lag to each formatting action and e.g. formatting a whole project is currently quite slow. However given that we already use this codepath for all projects using JDK 15 or higher, this seems okay.

