### PR TITLE
Format type annotation as part of the type, not part of the modifiers list

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpenOp.java
@@ -78,7 +78,7 @@ public abstract class OpenOp extends HasUniqueId implements Op {
      * But you can still get this (see test B20128760):
      *
      * <pre>
-     * Stream<ItemKey> itemIdsStream = stream(members).flatMap(m -> m.getFieldValues().entrySet().stream()
+     * {@code Stream<ItemKey> itemIdsStream = stream(members).flatMap(m -> m.getFieldValues().entrySet().stream()}
      *         .filter(...)
      *         .map(...));
      * </pre>

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -16,6 +16,7 @@ package com.palantir.javaformat;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -321,6 +322,28 @@ public final class OpsBuilder {
         ImmutableList<? extends Input.Token> tokens = input.getTokens();
         int idx = tokenI + skip;
         return idx < tokens.size() ? Optional.of(tokens.get(idx).getTok().getOriginalText()) : Optional.empty();
+    }
+
+    /**
+     * Returns the {@link Input.Tok}s starting at the current source position, which are satisfied by
+     * the given predicate.
+     */
+    public ImmutableList<Tok> peekTokens(int startPosition, Predicate<Input.Tok> predicate) {
+        ImmutableList<? extends Input.Token> tokens = input.getTokens();
+        Preconditions.checkState(
+                tokens.get(tokenI).getTok().getPosition() == startPosition,
+                "Expected the current token to be at position %s, found: %s",
+                startPosition,
+                tokens.get(tokenI));
+        ImmutableList.Builder<Tok> result = ImmutableList.builder();
+        for (int idx = tokenI; idx < tokens.size(); idx++) {
+            Tok tok = tokens.get(idx).getTok();
+            if (!predicate.apply(tok)) {
+                break;
+            }
+            result.add(tok);
+        }
+        return result.build();
     }
 
     /**

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -22,10 +22,10 @@ import static com.sun.source.tree.Tree.Kind.BLOCK;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.palantir.javaformat.Op;
 import com.palantir.javaformat.OpsBuilder;
 import com.palantir.javaformat.OpsBuilder.BlankLineWanted;
 import com.palantir.javaformat.java.JavaInputAstVisitor;
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.CaseTree;
@@ -114,7 +114,8 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
 
     private void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
         if (modifiers != null) {
-            builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));
+            List<AnnotationTree> annotations = visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty());
+            visitAnnotations(annotations, BreakOrNot.NO, BreakOrNot.YES);
         }
         scan(type, null);
         builder.breakOp(" ");
@@ -162,11 +163,9 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
 
     public void visitRecordDeclaration(ClassTree node) {
         sync(node);
-        List<Op> breaks = visitModifiers(
-                node.getModifiers(), Direction.VERTICAL, /* declarationAnnotationBreak= */ Optional.empty());
+        typeDeclarationModifiers(node.getModifiers());
         Verify.verify(node.getExtendsClause() == null);
         boolean hasSuperInterfaceTypes = !node.getImplementsClause().isEmpty();
-        builder.addAll(breaks);
         token("record");
         builder.space();
         visit(node.getSimpleName());

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -253,8 +253,7 @@ public final class FormatterTest {
                 + "import java.util.List;\n"
                 + "import javax.annotations.Nullable;\n\n"
                 + "public class ExampleTest {\n"
-                + "  @Nullable\n"
-                + "  List<?> xs;\n"
+                + "  @Nullable List<?> xs;\n"
                 + "}\n";
         assertThat(output).isEqualTo(expect);
     }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128588.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20128588.output
@@ -23,17 +23,11 @@ class Test {
     @Baz
     void f() {}
 
-    @Foo
-    @Bar
-    @Baz
-    static Object field;
+    @Foo @Bar @Baz static Object field;
 
     static @Foo @Bar @Baz Object field;
 
-    @Foo
-    @Bar
-    @Baz
-    Object field;
+    @Foo @Bar @Baz Object field;
 
     @Foo(xs = 42)
     @Bar
@@ -93,12 +87,7 @@ class Test {
     @Deprecated
     Object var;
 
-    @Deprecated
-    @Deprecated
-    @Deprecated
-    @Deprecated
-    @Deprecated
-    Object var;
+    @Deprecated @Deprecated @Deprecated @Deprecated @Deprecated Object var;
 
     @Deprecated(x = 42)
     @Deprecated

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20577626.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B20577626.output
@@ -1,9 +1,7 @@
 class B20577626 {
     private @Mock GsaConfigFlags mGsaConfig;
 
-    @Foo
-    @Bar
-    private @Mock GsaConfigFlags mGsaConfig;
+    @Foo @Bar private @Mock GsaConfigFlags mGsaConfig;
 
     @Foo
     abstract @Bar void m() {}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465477.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B21465477.output
@@ -1,16 +1,10 @@
 class B21465477 {
 
-    @Nullable
-    private final String simpleFieldName;
-
-    @Nullable
-    private final String shortFlagName;
-
+    @Nullable private final String simpleFieldName;
+    @Nullable private final String shortFlagName;
     private final String containerClassName;
     private final String type;
     private final String doc;
     private final DocLevel docLevel;
-
-    @Nullable
-    private final String altName;
+    @Nullable private final String altName;
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.input
@@ -44,11 +44,11 @@ class B24702438 {
 
   void f(
       int a,
-      @Nullable @Deprecated ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-      @Nullable @Deprecated ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-      @Nullable @Deprecated ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+      @Deprecated @Nullable ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+      @Deprecated @Nullable ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+      @Deprecated @Nullable ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
       int c) {}
   void g(
-      @Nullable @Deprecated ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-      @Nullable @Deprecated ImmutableList<String> veryVeryLoooooooooooooooooooooooooooooooooooooooooooooooooooooooong) {}
+      @Deprecated @Nullable ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+      @Deprecated @Nullable ImmutableList<String> veryVeryLoooooooooooooooooooooooooooooooooooooooooooooooooooooooong) {}
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/B24702438.output
@@ -1,22 +1,14 @@
 class B24702438 {
 
-    @Inject
-    int x;
+    @Inject int x;
 
-    @Inject
-    int y;
+    @Inject int y;
 
-    @Inject
-    int z;
+    @Inject int z;
 
-    @Inject
-    int x;
-
-    @Inject
-    int y;
-
-    @Inject
-    int z;
+    @Inject int x;
+    @Inject int y;
+    @Inject int z;
 
     // this is a comment
 
@@ -47,17 +39,17 @@ class B24702438 {
 
     void f(
             int a,
-            @Nullable @Deprecated
+            @Deprecated @Nullable
                     ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-            @Nullable @Deprecated
+            @Deprecated @Nullable
                     ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-            @Nullable @Deprecated
+            @Deprecated @Nullable
                     ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
             int c) {}
 
     void g(
-            @Nullable @Deprecated
+            @Deprecated @Nullable
                     ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
-            @Nullable @Deprecated
+            @Deprecated @Nullable
                     ImmutableList<String> veryVeryLoooooooooooooooooooooooooooooooooooooooooooooooooooooooong) {}
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1.output
@@ -16,15 +16,9 @@ class Test {
 
 class Test {
     final CreationMechanism creationMechanism;
-
-    @Nullable
-    final String creationUserAgent;
-
+    @Nullable final String creationUserAgent;
     final ClientId clientId;
-
-    @Nullable
-    final String creationUserAgentXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
-
+    @Nullable final String creationUserAgentXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
     final Token externalId;
 
     {
@@ -38,8 +32,7 @@ class Test {
 
 class Test {
 
-    @Nullable
-    final String creationUserAgent;
+    @Nullable final String creationUserAgent;
 
     {
         @Nullable final String creationUserAgent;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I13.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I13.output
@@ -1,7 +1,6 @@
 class I13 {
 
-    @Nullable
-    public int f;
+    @Nullable public int f;
 
     @Override
     public void m() {}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/TypeAnnotations.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/TypeAnnotations.input
@@ -1,0 +1,33 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class TypeAnnotations {
+
+  @Deprecated
+  public @Nullable Object foo() {}
+
+  public @Deprecated Object foo() {}
+
+  @Nullable Foo handle() {
+    @Nullable Bar bar = bar();
+    try (@Nullable Baz baz = baz()) {}
+  }
+
+  Foo(
+      @Nullable Bar //
+          param1, //
+      Baz //
+          param2) {}
+
+  void g(
+      @Deprecated @Nullable ImmutableList<String> veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+      @Deprecated @Nullable ImmutableList<String> veryVeryLoooooooooooooooooooooooooooooooooooooooooooooooooooooooong) {}
+
+  @Deprecated @Nullable TypeAnnotations() {}
+
+  enum Foo {
+    @Nullable
+    BAR;
+  }
+
+  @Nullable @Nullable Object doubleTrouble() {}
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/TypeAnnotations.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/TypeAnnotations.output
@@ -1,0 +1,37 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class TypeAnnotations {
+
+    @Deprecated
+    public @Nullable Object foo() {}
+
+    public @Deprecated Object foo() {}
+
+    @Nullable Foo handle() {
+        @Nullable Bar bar = bar();
+        try (@Nullable Baz baz = baz()) {}
+    }
+
+    Foo(
+            @Nullable Bar //
+                    param1, //
+            Baz //
+                    param2) {}
+
+    void g(
+            @Deprecated
+                    @Nullable ImmutableList<String>
+                            veryVeryLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,
+            @Deprecated
+                    @Nullable ImmutableList<String>
+                            veryVeryLoooooooooooooooooooooooooooooooooooooooooooooooooooooooong) {}
+
+    @Deprecated
+    @Nullable TypeAnnotations() {}
+
+    enum Foo {
+        @Nullable BAR;
+    }
+
+    @Nullable @Nullable Object doubleTrouble() {}
+}


### PR DESCRIPTION
This pull request cherry-picks commit https://github.com/google/google-java-format/commit/865cff01, "Format type annotation as part of the type, not part of the modifiers list" from google-java-format.  It includes a few other changes that are needed by that commit, or that reduce the size of the diffs against google-java-format.

There are some changes to `testdata/*.output` files -- that is, to the expected output of the formatter.  These relate to formatting of annotations and are due to changes in google-java-format.