### PR TITLE
Write configuration to IPR file as well as .idea to avoid errors in legacy projects

### DIFF
--- a/changelog/@unreleased/pr-810.v2.yml
+++ b/changelog/@unreleased/pr-810.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Write configuration to IPR file if it exists, as well as the .idea
+    directory, to avoid errors in legacy projects
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/810

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -86,10 +86,22 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
             createOrUpdateIdeaXmlFile(
                     project.file(".idea/externalDependencies.xml"),
                     node -> ConfigureJavaFormatterXml.configureExternalDependencies(node));
+            updateIdeaXmlFileIfExists(project.file(project.getName() + ".ipr"), node -> {
+                ConfigureJavaFormatterXml.configureJavaFormat(node, uris);
+                ConfigureJavaFormatterXml.configureExternalDependencies(node);
+            });
         });
     }
 
     private static void createOrUpdateIdeaXmlFile(File configurationFile, Consumer<Node> configure) {
+        updateIdeaXmlFile(configurationFile, configure, true);
+    }
+
+    private static void updateIdeaXmlFileIfExists(File configurationFile, Consumer<Node> configure) {
+        updateIdeaXmlFile(configurationFile, configure, false);
+    }
+
+    private static void updateIdeaXmlFile(File configurationFile, Consumer<Node> configure, boolean createIfAbsent) {
         Node rootNode;
         if (configurationFile.isFile()) {
             try {
@@ -98,6 +110,9 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
                 throw new RuntimeException("Couldn't parse existing configuration file: " + configurationFile, e);
             }
         } else {
+            if (!createIfAbsent) {
+                return;
+            }
             rootNode = new Node(null, "project", ImmutableMap.of("version", "4"));
         }
 


### PR DESCRIPTION
## Before this PR
If a project was previously imported from an IPR file (such as that generated by `./gradlew idea`), but later migrated to using the gradle integration, the project configuration is still stored in the `{rootProject}.ipr` file, not in the `.idea` directory. However, the PJF gradle plugin only updates the IPR file when running `./gradlew idea` - when importing a gradle project it only writes to the `.idea` directory.

This means that intellij tries to use whichever version of PJF was in use when the project was migrated to gradle, which may not even exist on disk any more, causing errors whenever it tries to run.

## After this PR
==COMMIT_MSG==
Write configuration to IPR file if it exists, as well as the .idea directory, to avoid errors in legacy projects
==COMMIT_MSG==

## Possible downsides?
Maybe we should just migrate the legacy .ipr projects to using the .idea format? But I don't know that it's automatable, and probably isn't the responsibility of this plugin anyway.