### PR TITLE
README clarifies the 'before' examples are g-j-f, not unformatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Many other languages have already adopted formatters enthusiastically, including
 
 ## Motivation & examples
 
-(1) before:
+(1) google-java-format output:
 
 ```java
 private static void configureResolvedVersionsWithVersionMapping(Project project) {
@@ -53,7 +53,7 @@ private static void configureResolvedVersionsWithVersionMapping(Project project)
 }
 ```
 
-(1) after:
+(1) palantir-java-format output:
 
 ```java
 private static void configureResolvedVersionsWithVersionMapping(Project project) {
@@ -69,7 +69,7 @@ private static void configureResolvedVersionsWithVersionMapping(Project project)
 }
 ```
 
-(2) before:
+(2) google-java-format output:
 
 ```java
 private static GradleException notFound(
@@ -87,7 +87,7 @@ private static GradleException notFound(
 }
 ```
 
-(2) after:
+(2) palantir-java-format output:
 
 ```java
 private static GradleException notFound(String group, String name, Configuration configuration) {


### PR DESCRIPTION
## Before this PR

An issue was filed because the README wasn't completely clear https://github.com/palantir/palantir-java-format/issues/823

## After this PR
==COMMIT_MSG==
README clarifies the 'before' examples are g-j-f, not unformatted
==COMMIT_MSG==

## Possible downsides?


