### PR TITLE
Stop using the Save Actions plugin (broken in IntelliJ 2023.1) and use native format on save

### DIFF
--- a/changelog/@unreleased/pr-862.v2.yml
+++ b/changelog/@unreleased/pr-862.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Stop using the Save Actions plugin (broken in IntelliJ 2023.1) and
+    use native format on save (requires IntelliJ >=2021.2)
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/862

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -52,13 +52,16 @@ class ConfigureJavaFormatterXml {
                 .orElse(true)
 
         if (myRunOnSaveAlreadySet && myAllFileTypesSelectedAlreadySet) {
-            // If the user has already configured IntelliJ to format all file types, we
+            // If the user has already configured IntelliJ to format all file types and turned on formatting on save,
+            // we leave the configuration as is as it will format java code, and we don't want to disable formatting
+            // for other file types
             return
         }
 
+        // Otherwise we setup intellij to not format all files...
         matchOrCreateChild(formatOnSaveOptions, 'option', [name: 'myAllFileTypesSelected']).attributes().put('value', 'false')
 
-
+        // ...but ensure java is formatted
         def mySelectedFileTypes = matchOrCreateChild(formatOnSaveOptions, 'option', [name: 'mySelectedFileTypes'])
         def set = matchOrCreateChild(mySelectedFileTypes, 'set')
         matchOrCreateChild(set, 'option', [value: 'JAVA'])

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -66,6 +66,10 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
             ConfigureJavaFormatterXml.configureJavaFormat(xmlProvider.asNode(), uris);
             ConfigureJavaFormatterXml.configureExternalDependencies(xmlProvider.asNode());
         });
+
+        ideaModel.getWorkspace().getIws().withXml(xmlProvider -> {
+            ConfigureJavaFormatterXml.configureFormatOnSave(xmlProvider.asNode());
+        });
     }
 
     private static void configureIntelliJImport(Project project, Configuration implConfiguration) {
@@ -86,9 +90,16 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
             createOrUpdateIdeaXmlFile(
                     project.file(".idea/externalDependencies.xml"),
                     node -> ConfigureJavaFormatterXml.configureExternalDependencies(node));
+            createOrUpdateIdeaXmlFile(
+                    project.file(".idea/workspace.xml"), node -> ConfigureJavaFormatterXml.configureFormatOnSave(node));
+
+            // Still configure legacy idea if using intellij import
             updateIdeaXmlFileIfExists(project.file(project.getName() + ".ipr"), node -> {
                 ConfigureJavaFormatterXml.configureJavaFormat(node, uris);
                 ConfigureJavaFormatterXml.configureExternalDependencies(node);
+            });
+            updateIdeaXmlFileIfExists(project.file(project.getName() + ".iws"), node -> {
+                ConfigureJavaFormatterXml.configureFormatOnSave(node);
             });
         });
     }

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -104,6 +104,104 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         xmlToString(node) == EXPECTED
     }
 
+    void 'adds FormatOnSave block where none exists'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="JAVA"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
+    void 'adds Java to existing FormatOnSave block'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="Go"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="Go"/>
+                    <option value="JAVA"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
+    void 'if all file types are already formatted on save, dont change anything'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <!-- if myAllFileTypesSelected does not exist, it defaults to true -->
+              </component>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
     static String xmlToString(Node node) {
         StringWriter sw = new StringWriter();
         XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(sw));


### PR DESCRIPTION
## Before this PR
We use the [Save Actions IntelliJ plugin](https://plugins.jetbrains.com/plugin/7642-save-actions) but it is [broken in IntelliJ 2023.1](https://github.com/dubreuia/intellij-plugin-save-actions/issues/427) and is not maintained and will not have a new release.

## After this PR
==COMMIT_MSG==
Stop using the Save Actions plugin (broken in IntelliJ 2023.1) and use native format on save (requires IntelliJ >=2021.2)
==COMMIT_MSG==

In 2021.2, IntelliJ introduced a [new built in reformat on save feature](https://blog.jetbrains.com/idea/2021/07/intellij-idea-2021-2/#key_updates:~:text=We%E2%80%99ve%20added%20several%20actions%20that%20the%20IDE%20will%20initiate%20when%20you%20save%20the%20project%2C%20including%20reformatting%20code). We configure this instead rather than using a custom plugin.

## Possible downsides?
The suggesting of Save Actions [lives in baseline](https://github.com/palantir/gradle-baseline/pull/2547) unfortunately
