### PR TITLE
List our IntelliJ compatibility correctly

### DIFF
--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Update intellij compatibility range in IntelliJ plugin `plugin.xml`
+    metadata file.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/874

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,7 @@
        See https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html#modules-specific-to-functionality
    -->
   <depends>com.intellij.modules.java</depends>
+  <idea-version since-build="193"/>
 
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable"


### PR DESCRIPTION
## Before this PR
As per support email reply from Jetbrains, our 2.30.0 release is not being approved as it is incompatible with builds lower than 193. We can fix this temporarily by changing it through the UI, or we can fix it forever by modifying the `plugin.xml` included with the plugin.

## After this PR
==COMMIT_MSG==
Update intellij compatibility range in IntelliJ plugin `plugin.xml` metadata file.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

