### PR TITLE
Update IntelliJ compatibility bounds correctly

### DIFF
--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Update intellij compatibility range in IntelliJ plugin `plugin.xml`
+    metadata file, but hopefully correctly this time.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/875

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -35,7 +35,7 @@ tasks.runIde {
 patchPluginXml {
     pluginDescription = "Formats source code using the palantir-java-format tool."
     version = project.version
-    sinceBuild = '182' // TODO: test against this version of IntelliJ to ensure no regressions
+    sinceBuild = '193' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
 }
 

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,6 @@
        See https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html#modules-specific-to-functionality
    -->
   <depends>com.intellij.modules.java</depends>
-  <idea-version since-build="193"/>
 
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable"


### PR DESCRIPTION
## Before this PR
In #874, I tried to update the minimum intellij version this is listed to work with. However, [it didn't work](https://plugins.jetbrains.com/plugin/13180-palantir-java-format/versions/stable/337985) as the `patchPluginXml` task changes the `plugin.xml` file.

## After this PR
Use the correct intellij version bound.

==COMMIT_MSG==
Update intellij compatibility range in IntelliJ plugin `plugin.xml` metadata file, but hopefully correctly this time.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

