### PR TITLE
Fix NoSuchMethodError happening on JDK 21 (fixes #885)

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
@@ -241,7 +241,7 @@ public class RemoveUnusedImports {
         return replacements;
     }
 
-    private static String getSimpleName(JCImport importTree) {
+    private static String getSimpleName(ImportTree importTree) {
         return importTree.getQualifiedIdentifier() instanceof JCIdent
                 ? ((JCIdent) importTree.getQualifiedIdentifier()).getName().toString()
                 : ((JCFieldAccess) importTree.getQualifiedIdentifier())


### PR DESCRIPTION
See #885 for the full description of this issue.
The PR simply changed the argument to the interface so that the return type is not changed across JDKs.