### PR TITLE
Run Gradle Wrapper validation on PR events

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,10 +1,10 @@
 name: "Validate Gradle Wrapper"
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validation:
-    name: "Validation"
+    name: "Validate Gradle Wrapper"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
## Before this PR

We don't have the "approve workflow run" button available and are unable to run the Gradle validation action on forks ([docs](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)).

It might be, that the workflow is only triggered on `push` but not on `pull_request`, so there is no workflow event for the PR. 

## After this PR
Following the setup docs here: https://github.com/gradle/wrapper-validation-action

==COMMIT_MSG==
Run Gradle Wrapper validation on PR events
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

