### PR TITLE
feat: allow configurable max line length

### DIFF
--- a/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
+++ b/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
@@ -57,8 +57,11 @@ public final class JavaFormatterOptions {
 
     private final Style style;
 
-    private JavaFormatterOptions(Style style) {
+    private final int maxLineLength;
+
+    private JavaFormatterOptions(Style style, int maxLineLength) {
         this.style = style;
+        this.maxLineLength = maxLineLength >= 0 ? maxLineLength : style.maxLineLength();
     }
 
     /** Returns the multiplier for the unit of indent. */
@@ -67,7 +70,7 @@ public final class JavaFormatterOptions {
     }
 
     public int maxLineLength() {
-        return style.maxLineLength();
+        return maxLineLength;
     }
 
     /** Returns the code style. */
@@ -90,6 +93,8 @@ public final class JavaFormatterOptions {
         // default is still GOOGLE just because lots of hand-rolled tests rely on this behaviour
         private Style style = Style.GOOGLE;
 
+        private int maxLineLength = -1;
+
         private Builder() {}
 
         public Builder style(Style style) {
@@ -97,8 +102,13 @@ public final class JavaFormatterOptions {
             return this;
         }
 
+        public Builder maxLineLength(int maxLineLength) {
+            this.maxLineLength = maxLineLength;
+            return this;
+        }
+
         public JavaFormatterOptions build() {
-            return new JavaFormatterOptions(style);
+            return new JavaFormatterOptions(style, maxLineLength);
         }
     }
 }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/CommandLineOptions.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/CommandLineOptions.java
@@ -34,6 +34,7 @@ final class CommandLineOptions {
     private final ImmutableList<Integer> lengths;
     private final boolean aosp;
     private final boolean palantirStyle;
+    private final int maxLineLength;
     private final boolean version;
     private final boolean help;
     private final boolean stdin;
@@ -55,6 +56,7 @@ final class CommandLineOptions {
             ImmutableList<Integer> lengths,
             boolean aosp,
             boolean palantirStyle,
+            int maxLineLength,
             boolean version,
             boolean help,
             boolean stdin,
@@ -74,6 +76,7 @@ final class CommandLineOptions {
         this.lengths = lengths;
         this.aosp = aosp;
         this.palantirStyle = palantirStyle;
+        this.maxLineLength = maxLineLength;
         this.version = version;
         this.help = help;
         this.stdin = stdin;
@@ -125,6 +128,11 @@ final class CommandLineOptions {
     /** Use Palantir style instead of Google Style. */
     boolean palantirStyle() {
         return palantirStyle;
+    }
+
+    /** Use a custom max line length. */
+    int maxLineLength() {
+        return maxLineLength;
     }
 
     /** Print the version. */
@@ -199,6 +207,7 @@ final class CommandLineOptions {
         private boolean inPlace = false;
         private boolean aosp = false;
         private boolean palantirStyle = false;
+        private int maxLineLength = -1;
         private boolean version = false;
         private boolean help = false;
         private boolean stdin = false;
@@ -247,6 +256,11 @@ final class CommandLineOptions {
 
         Builder palantirStyle(boolean palantirStyle) {
             this.palantirStyle = palantirStyle;
+            return this;
+        }
+
+        Builder maxLineLength(int maxLineLength) {
+            this.maxLineLength = maxLineLength;
             return this;
         }
 
@@ -316,6 +330,7 @@ final class CommandLineOptions {
                     lengths.build(),
                     aosp,
                     palantirStyle,
+                    maxLineLength,
                     version,
                     help,
                     stdin,

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/CommandLineOptionsParser.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/CommandLineOptionsParser.java
@@ -96,6 +96,9 @@ final class CommandLineOptionsParser {
                 case "-palantir":
                     optionsBuilder.palantirStyle(true);
                     break;
+                case "--max-line-length":
+                    optionsBuilder.maxLineLength(parseInteger(it, flag, value));
+                    break;
                 case "--version":
                 case "-version":
                 case "-v":

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/Main.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/Main.java
@@ -96,6 +96,7 @@ public final class Main {
         // TODO(someone): update this to always use Style.PALANTIR
         JavaFormatterOptions options = JavaFormatterOptions.builder()
                 .style(parameters.aosp() ? Style.AOSP : parameters.palantirStyle() ? Style.PALANTIR : Style.GOOGLE)
+                .maxLineLength(parameters.maxLineLength())
                 .build();
 
         if (parameters.stdin()) {


### PR DESCRIPTION
## Before this PR
The max line length for Palantir is 120 characters.

## After this PR
The max line length for Palantir java format is configurable.
==COMMIT_MSG==
Enable users to override max line length.
==COMMIT_MSG==

## Possible downsides?
We are introducing configurability, which diverts from the way GJF handles things.

## Notes
1. This is a draft to open up discussion. Of course, we would need to provide tests for this change, as well as enable ways for setting the configuration in the IntelliJ and Gradle plugins. I wanted to be sure the owners were willing to go this way before investing too much time.
2. I'm unsure on how to tackle the `com.palantir.javaformat.java.FormatterService` for allowing configuration. I'm open for suggestions here.

This resolves #859 