### PR TITLE
Optimise imports on save

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,17 +1,18 @@
-versionOverrides: {}
 acceptedBreaks:
   "0.3.9":
-    com.palantir.javaformat:palantir-java-format-spi: []
     com.palantir.javaformat:gradle-palantir-java-format:
-      - code: "java.class.removed"
-        old: "class com.palantir.javaformat.gradle.ConfigureExternalDependenciesXml"
-        new: null
-        justification: "nobody used this directly"
-      - code: "java.class.removed"
-        old: "class com.palantir.javaformat.gradle.ConfigurePalantirJavaFormatXml"
-        new: null
-        justification: "nobody used this directly"
-      - code: "java.class.removed"
-        old: "class com.palantir.javaformat.gradle.UpdateIntellijXmlTask"
-        new: null
-        justification: "nobody used this directly"
+    - code: "java.class.removed"
+      old: "class com.palantir.javaformat.gradle.ConfigureExternalDependenciesXml"
+      justification: "nobody used this directly"
+    - code: "java.class.removed"
+      old: "class com.palantir.javaformat.gradle.ConfigurePalantirJavaFormatXml"
+      justification: "nobody used this directly"
+    - code: "java.class.removed"
+      old: "class com.palantir.javaformat.gradle.UpdateIntellijXmlTask"
+      justification: "nobody used this directly"
+  "2.33.0":
+    com.palantir.javaformat:gradle-palantir-java-format:
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.javaformat.gradle.ConfigureJavaFormatterXml::configureFormatOnSave(groovy.util.Node)"
+      new: "method void com.palantir.javaformat.gradle.ConfigureJavaFormatterXml::configureFormatOnSave(groovy.util.Node)"
+      justification: "Not public api, not split over multiple jars"

--- a/changelog/@unreleased/pr-906.v2.yml
+++ b/changelog/@unreleased/pr-906.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure imports are optimised on save, as well as formatting.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/906

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -35,11 +35,21 @@ class ConfigureJavaFormatterXml {
         matchOrCreateChild(externalDependencies, 'plugin', [id: 'palantir-java-format'])
     }
 
-    static void configureFormatOnSave(Node rootNode) {
-        def formatOnSaveOptions = matchOrCreateChild(rootNode, 'component', [name: 'FormatOnSaveOptions'])
+    static void configureWorkspaceXml(Node rootNode) {
+        configureFormatOnSave(rootNode)
+        configureOptimizeOnSave(rootNode)
+    }
 
+    private static void configureFormatOnSave(Node rootNode) {
+        configureOnSaveAction(matchOrCreateChild(rootNode, 'component', [name: 'FormatOnSaveOptions']))
+    }
 
-        def myRunOnSave = matchOrCreateChild(formatOnSaveOptions, 'option', [name: 'myRunOnSave'])
+    private static void configureOptimizeOnSave(Node rootNode) {
+        configureOnSaveAction(matchOrCreateChild(rootNode, 'component', [name: 'OptimizeOnSaveOptions']))
+    }
+
+    private static void configureOnSaveAction(Node onSaveOptions) {
+        def myRunOnSave = matchOrCreateChild(onSaveOptions, 'option', [name: 'myRunOnSave'])
 
         def myRunOnSaveAlreadySet = Optional.ofNullable(myRunOnSave.attribute('value'))
                 .map(Boolean::parseBoolean)
@@ -47,7 +57,7 @@ class ConfigureJavaFormatterXml {
 
         myRunOnSave.attributes().put('value', 'true')
 
-        def myAllFileTypesSelectedAlreadySet = matchChild(formatOnSaveOptions, 'option', [name: 'myAllFileTypesSelected'])
+        def myAllFileTypesSelectedAlreadySet = matchChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected'])
                 .map { Boolean.parseBoolean(it.attribute('value')) }
                 .orElse(true)
 
@@ -59,10 +69,10 @@ class ConfigureJavaFormatterXml {
         }
 
         // Otherwise we setup intellij to not format all files...
-        matchOrCreateChild(formatOnSaveOptions, 'option', [name: 'myAllFileTypesSelected']).attributes().put('value', 'false')
+        matchOrCreateChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected']).attributes().put('value', 'false')
 
         // ...but ensure java is formatted
-        def mySelectedFileTypes = matchOrCreateChild(formatOnSaveOptions, 'option', [name: 'mySelectedFileTypes'])
+        def mySelectedFileTypes = matchOrCreateChild(onSaveOptions, 'option', [name: 'mySelectedFileTypes'])
         def set = matchOrCreateChild(mySelectedFileTypes, 'set')
         matchOrCreateChild(set, 'option', [value: 'JAVA'])
     }

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -68,7 +68,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
         });
 
         ideaModel.getWorkspace().getIws().withXml(xmlProvider -> {
-            ConfigureJavaFormatterXml.configureFormatOnSave(xmlProvider.asNode());
+            ConfigureJavaFormatterXml.configureWorkspaceXml(xmlProvider.asNode());
         });
     }
 
@@ -91,7 +91,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
                     project.file(".idea/externalDependencies.xml"),
                     node -> ConfigureJavaFormatterXml.configureExternalDependencies(node));
             createOrUpdateIdeaXmlFile(
-                    project.file(".idea/workspace.xml"), node -> ConfigureJavaFormatterXml.configureFormatOnSave(node));
+                    project.file(".idea/workspace.xml"), node -> ConfigureJavaFormatterXml.configureWorkspaceXml(node));
 
             // Still configure legacy idea if using intellij import
             updateIdeaXmlFileIfExists(project.file(project.getName() + ".ipr"), node -> {
@@ -99,7 +99,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
                 ConfigureJavaFormatterXml.configureExternalDependencies(node);
             });
             updateIdeaXmlFileIfExists(project.file(project.getName() + ".iws"), node -> {
-                ConfigureJavaFormatterXml.configureFormatOnSave(node);
+                ConfigureJavaFormatterXml.configureWorkspaceXml(node);
             });
         });
     }

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -17,6 +17,7 @@
 package com.palantir.javaformat.gradle
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ConfigureJavaFormatterXmlTest extends Specification {
 
@@ -60,6 +61,7 @@ class ConfigureJavaFormatterXmlTest extends Specification {
           </component>
         </root>
         """.stripIndent()
+    public static final ArrayList<String> ACTIONS_ON_SAVE = ['Format', 'Optimize']
 
     void testConfigure_missingEntireBlock_added() {
         def node = new XmlParser().parseText(MISSING_ENTIRE_BLOCK)
@@ -104,7 +106,8 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         xmlToString(node) == EXPECTED
     }
 
-    void 'adds FormatOnSave block where none exists'() {
+    @Unroll
+    void 'adds #action OnSave block where none exists'(action) {
         // language=xml
         def node = new XmlParser().parseText '''
             <root>
@@ -112,33 +115,34 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         '''.stripIndent(true)
 
         when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
+        ConfigureJavaFormatterXml.configureWorkspaceXml(node)
+
+        def newXml = xmlSubcomponentToString(node, "${action}OnSaveOptions").strip()
 
         then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="FormatOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
-                <option name="mySelectedFileTypes">
-                  <set>
-                    <option value="JAVA"/>
-                  </set>
-                </option>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
+        def expected = """
+            <component name="${action}OnSaveOptions">
+              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="false"/>
+              <option name="mySelectedFileTypes">
+                <set>
+                  <option value="JAVA"/>
+                </set>
+              </option>
+            </component>
+        """.stripIndent(true).strip()
 
         newXml == expected
+
+        where:
+        action << ACTIONS_ON_SAVE
     }
 
-    void 'adds Java to existing FormatOnSave block'() {
-        // language=xml
-        def node = new XmlParser().parseText '''
+    @Unroll
+    void 'adds Java to existing #action OnSave block'(action) {
+        def node = new XmlParser().parseText """
             <root>
-              <component name="FormatOnSaveOptions">
+              <component name="${action}OnSaveOptions">
                 <option name="myRunOnSave" value="true"/>
                 <option name="myAllFileTypesSelected" value="false"/>
                 <option name="mySelectedFileTypes">
@@ -148,156 +152,62 @@ class ConfigureJavaFormatterXmlTest extends Specification {
                 </option>
               </component>
             </root>
-        '''.stripIndent(true)
+        """.stripIndent(true)
 
         when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
+        ConfigureJavaFormatterXml.configureWorkspaceXml(node)
+        def newXml = xmlSubcomponentToString(node, "${action}OnSaveOptions")
 
         then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="FormatOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
-                <option name="mySelectedFileTypes">
-                  <set>
-                    <option value="Go"/>
-                    <option value="JAVA"/>
-                  </set>
-                </option>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
+        def expected = """
+            <component name="${action}OnSaveOptions">
+              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="false"/>
+              <option name="mySelectedFileTypes">
+                <set>
+                  <option value="Go"/>
+                  <option value="JAVA"/>
+                </set>
+              </option>
+            </component>
+        """.stripIndent(true).strip()
 
         newXml == expected
+
+        where:
+        action << ACTIONS_ON_SAVE
     }
 
-    void 'if all file types are already formatted on save, dont change anything'() {
-        // language=xml
-        def node = new XmlParser().parseText '''
+    @Unroll
+    void 'if all file types are already configured to #action on save, dont change anything'() {
+        def node = new XmlParser().parseText """
             <root>
-              <component name="FormatOnSaveOptions">
+              <component name="${action}OnSaveOptions">
                 <option name="myRunOnSave" value="true"/>
                 <!-- if myAllFileTypesSelected does not exist, it defaults to true -->
               </component>
             </root>
-        '''.stripIndent(true)
+        """.stripIndent(true)
 
         when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
+        ConfigureJavaFormatterXml.configureWorkspaceXml(node)
+        def newXml = xmlSubcomponentToString(node, "${action}OnSaveOptions").strip()
 
         then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="FormatOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
+        def expected = """
+            <component name="${action}OnSaveOptions">
+              <option name="myRunOnSave" value="true"/>
+            </component>
+        """.stripIndent(true).strip()
 
         newXml == expected
+
+        where:
+        action << ACTIONS_ON_SAVE
     }
 
-    void 'adds OptimizeOnSave block where none exists'() {
-        // language=xml
-        def node = new XmlParser().parseText '''
-            <root>
-            </root>
-        '''.stripIndent(true)
-
-        when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
-
-        then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="OptimizeOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
-                <option name="mySelectedFileTypes">
-                  <set>
-                    <option value="JAVA"/>
-                  </set>
-                </option>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
-
-        newXml == expected
-    }
-
-    void 'adds Java to existing OptimizeOnSave block'() {
-        // language=xml
-        def node = new XmlParser().parseText '''
-            <root>
-              <component name="OptimizeOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
-                <option name="mySelectedFileTypes">
-                  <set>
-                    <option value="Go"/>
-                  </set>
-                </option>
-              </component>
-            </root>
-        '''.stripIndent(true)
-
-        when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
-
-        then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="OptimizeOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
-                <option name="mySelectedFileTypes">
-                  <set>
-                    <option value="Go"/>
-                    <option value="JAVA"/>
-                  </set>
-                </option>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
-
-        newXml == expected
-    }
-
-    void 'if all file types are already optimised on save, dont change anything'() {
-        // language=xml
-        def node = new XmlParser().parseText '''
-            <root>
-              <component name="FormatOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <!-- if myAllFileTypesSelected does not exist, it defaults to true -->
-              </component>
-            </root>
-        '''.stripIndent(true)
-
-        when:
-        ConfigureJavaFormatterXml.configureFormatOnSave(node)
-        def newXml = xmlToString(node).strip()
-
-        then:
-        // language=xml
-        def expected = '''
-            <root>
-              <component name="OptimizeOnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-              </component>
-            </root>
-        '''.stripIndent(true).strip()
-
-        newXml == expected
+    private static String xmlSubcomponentToString(Node node, String name) {
+        xmlToString(node.children().find { it.@name == name }).strip()
     }
 
     static String xmlToString(Node node) {

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -202,6 +202,104 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         newXml == expected
     }
 
+    void 'adds OptimizeOnSave block where none exists'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="OptimizeOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="JAVA"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
+    void 'adds Java to existing OptimizeOnSave block'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+              <component name="OptimizeOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="Go"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="OptimizeOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="Go"/>
+                    <option value="JAVA"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
+    void 'if all file types are already optimised on save, dont change anything'() {
+        // language=xml
+        def node = new XmlParser().parseText '''
+            <root>
+              <component name="FormatOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+                <!-- if myAllFileTypesSelected does not exist, it defaults to true -->
+              </component>
+            </root>
+        '''.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureFormatOnSave(node)
+        def newXml = xmlToString(node).strip()
+
+        then:
+        // language=xml
+        def expected = '''
+            <root>
+              <component name="OptimizeOnSaveOptions">
+                <option name="myRunOnSave" value="true"/>
+              </component>
+            </root>
+        '''.stripIndent(true).strip()
+
+        newXml == expected
+    }
+
     static String xmlToString(Node node) {
         StringWriter sw = new StringWriter();
         XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(sw));


### PR DESCRIPTION
## Before this PR
In #862, we moved away from using the "Save Actions" plugin to using the native IntelliJ "Actions on Save" feature.

An oversight when doing this was that the Save Actions plugin was [configured to use optimise imports as well](https://github.com/palantir/gradle-baseline/pull/2547/files#diff-9ba1b31dd546fef876597b27d8daac1a487f84bdb2584543574d17d9da1e5359L586). However, in #862 we did not enable optimise on save.

This mostly flew under the radar as most devs have manually enabled the "Optimize Imports on the Fly" option in intellij at soe point in the last $years, and this mostly fixes the inputs for you as you code. However, some devs do not have this, especially devs who are new or are low code who are least equipped to resolve this problem.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure imports are optimised on save, as well as formatting.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

