### PR TITLE
Fix NoSuchMethodError happening on JDK 21

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
@@ -253,7 +253,7 @@ public class RemoveUnusedImports {
             JCCompilationUnit unit,
             Set<String> usedNames,
             Multimap<String, Range<Integer>> usedInJavadoc,
-            JCImport importTree,
+            ImportTree importTree,
             String simpleName) {
         String qualifier = ((JCFieldAccess) importTree.getQualifiedIdentifier())
                 .getExpression()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
(fixes #885)

The previous PR https://github.com/palantir/palantir-java-format/pull/886 has 
been merged but unfortunately is not sufficient to allow the code formatter to
run on JDK 21.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JLine Parent 3.23.1-SNAPSHOT:
[INFO] 
[INFO] JLine Parent ....................................... SUCCESS [  0.888 s]
[INFO] JLine Native Library ............................... FAILURE [  0.077 s]
[INFO] JLine Terminal ..................................... SKIPPED
[INFO] JLine JNA Terminal ................................. SKIPPED
[INFO] JLine JANSI Terminal ............................... SKIPPED
[INFO] JLine Reader ....................................... SKIPPED
[INFO] JLine Style ........................................ SKIPPED
[INFO] JLine Builtins ..................................... SKIPPED
[INFO] JLine Console ...................................... SKIPPED
[INFO] JLine Groovy ....................................... SKIPPED
[INFO] JLine Remote SSH ................................... SKIPPED
[INFO] JLine Remote Telnet ................................ SKIPPED
[INFO] JLine Demo ......................................... SKIPPED
[INFO] JLine Graal Demo ................................... SKIPPED
[INFO] JLine Bundle ....................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.005 s (Wall Clock)
[INFO] Finished at: 2023-08-02T10:33:31+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.37.0:apply (default) on project jline-native: Execution default of goal 
com.diffplug.spotless:spotless-maven-plugin:2.37.0:apply failed: An API incompatibility was encountered while executing com.diffplug.spotless:spotless-maven-plugin:2.37.0:apply: 
java.lang.NoSuchMethodError: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.diffplug.spotless:spotless-maven-plugin:2.37.0-1699762855
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/gnodet/.m2/repository/com/diffplug/spotless/spotless-maven-plugin/2.37.0/spotless-maven-plugin-2.37.0.jar
[ERROR] urls[1] = file:/Users/gnodet/.m2/repository/com/diffplug/spotless/spotless-lib/2.39.0/spotless-lib-2.39.0.jar
[ERROR] urls[2] = file:/Users/gnodet/.m2/repository/com/diffplug/spotless/spotless-lib-extra/2.39.0/spotless-lib-extra-2.39.0.jar
[ERROR] urls[3] = file:/Users/gnodet/.m2/repository/com/googlecode/concurrent-trees/concurrent-trees/2.6.1/concurrent-trees-2.6.1.jar
[ERROR] urls[4] = file:/Users/gnodet/.m2/repository/dev/equo/ide/solstice/1.3.1/solstice-1.3.1.jar
[ERROR] urls[5] = file:/Users/gnodet/.m2/repository/com/diffplug/durian/durian-swt.os/4.2.0/durian-swt.os-4.2.0.jar
[ERROR] urls[6] = file:/Users/gnodet/.m2/repository/org/eclipse/platform/org.eclipse.osgi/3.18.300/org.eclipse.osgi-3.18.300.jar
[ERROR] urls[7] = file:/Users/gnodet/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar
[ERROR] urls[8] = file:/Users/gnodet/.m2/repository/com/squareup/okhttp3/okhttp/4.10.0/okhttp-4.10.0.jar
[ERROR] urls[9] = file:/Users/gnodet/.m2/repository/com/squareup/okio/okio-jvm/3.0.0/okio-jvm-3.0.0.jar
[ERROR] urls[10] = file:/Users/gnodet/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.5.31/kotlin-stdlib-jdk8-1.5.31.jar
[ERROR] urls[11] = file:/Users/gnodet/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.5.31/kotlin-stdlib-jdk7-1.5.31.jar
[ERROR] urls[12] = file:/Users/gnodet/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib-common/1.5.31/kotlin-stdlib-common-1.5.31.jar
[ERROR] urls[13] = file:/Users/gnodet/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib/1.6.20/kotlin-stdlib-1.6.20.jar
[ERROR] urls[14] = file:/Users/gnodet/.m2/repository/org/jetbrains/annotations/13.0/annotations-13.0.jar
[ERROR] urls[15] = file:/Users/gnodet/.m2/repository/com/diffplug/durian/durian-core/1.2.0/durian-core-1.2.0.jar
[ERROR] urls[16] = file:/Users/gnodet/.m2/repository/com/diffplug/durian/durian-collect/1.2.0/durian-collect-1.2.0.jar
[ERROR] urls[17] = file:/Users/gnodet/.m2/repository/org/codehaus/plexus/plexus-resources/1.2.0/plexus-resources-1.2.0.jar
[ERROR] urls[18] = file:/Users/gnodet/.m2/repository/org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.jar
[ERROR] urls[19] = file:/Users/gnodet/.m2/repository/org/eclipse/jgit/org.eclipse.jgit/6.5.0.202303070854-r/org.eclipse.jgit-6.5.0.202303070854-r.jar
[ERROR] urls[20] = file:/Users/gnodet/.m2/repository/com/googlecode/javaewah/JavaEWAH/1.1.13/JavaEWAH-1.1.13.jar
[ERROR] urls[21] = file:/Users/gnodet/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -r
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JLine Parent 3.23.1-SNAPSHOT:
[INFO] 
[INFO] JLine Parent ....................................... SUCCESS [  0.953 s]
[INFO] JLine Native Library ............................... SUCCESS [  1.371 s]
[INFO] JLine Terminal ..................................... SUCCESS [  3.569 s]
[INFO] JLine JNA Terminal ................................. SUCCESS [  3.136 s]
[INFO] JLine JANSI Terminal ............................... SUCCESS [  2.944 s]
[INFO] JLine Reader ....................................... SUCCESS [  4.569 s]
[INFO] JLine Style ........................................ SUCCESS [  2.647 s]
[INFO] JLine Builtins ..................................... SUCCESS [  3.981 s]
[INFO] JLine Console ...................................... SUCCESS [  4.112 s]
[INFO] JLine Groovy ....................................... SUCCESS [  3.109 s]
[INFO] JLine Remote SSH ................................... SUCCESS [  1.935 s]
[INFO] JLine Remote Telnet ................................ SUCCESS [  1.849 s]
[INFO] JLine Demo ......................................... SUCCESS [  2.101 s]
[INFO] JLine Graal Demo ................................... SUCCESS [  1.794 s]
[INFO] JLine Bundle ....................................... SUCCESS [  3.898 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.806 s (Wall Clock)
[INFO] Finished at: 2023-08-02T10:44:55+02:00
[INFO] ------------------------------------------------------------------------
```

## Possible downsides?
No real downsides
