### PR TITLE
Handle `final var` lambda variables

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -1237,7 +1237,10 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 token(",");
                 builder.breakOp(" ");
             }
-            scan(parameter, null);
+            visitVariables(
+                    ImmutableList.of(parameter),
+                    DeclarationKind.NONE,
+                    inlineAnnotationDirection(parameter.getModifiers()));
             first = false;
         }
         if (parens) {

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I959.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I959.input
@@ -1,0 +1,5 @@
+class I959 {
+    public void test() {
+      new File(".").listFiles((final var dir, final var name) -> true);
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I959.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I959.output
@@ -1,0 +1,5 @@
+class I959 {
+    public void test() {
+        new File(".").listFiles((final var dir, final var name) -> true);
+    }
+}


### PR DESCRIPTION
Backported the following upstream fix of @cushon: google/google-java-format@1fe678942551b446d589c0fe0ad5319ccf17ffa3
Original issue: google/google-java-format#959

## Before this PR
Processing lambda functions with arguments declared with `final var` produces: `error: did not generate token "final"`

## After this PR
Process lambda functions with arguments declared with `final var` no longer produces an error message.