### PR TITLE
Java 21: Pattern Matching + StringTemplate JEP-430 + Unnamed JEP-445

### DIFF
--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -49,7 +49,7 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += jvmArgList
 
     if (JavaVersion.current() < JavaVersion.VERSION_14) {
-        excludes = ['**/Java14InputAstVisitor.java']
+        excludes = ['**/Java14InputAstVisitor.java', '**/Java21InputAstVisitor.java']
     }
 }
 
@@ -62,7 +62,7 @@ tasks.withType(Javadoc).configureEach {
     options.optionFiles << file('../gradle/javadoc.options')
 
     if (JavaVersion.current() < JavaVersion.VERSION_14) {
-        exclude '**/Java14InputAstVisitor.java'
+        excludes = ['**/Java14InputAstVisitor.java', '**/Java21InputAstVisitor.java']
     }
 }
 
@@ -77,10 +77,111 @@ tasks.named("test") {
     systemProperty 'junit.jupiter.execution.parallel.mode.default', 'concurrent'
 }
 
-// necessary to compile Java14InputAstVisitor
-idea {
-    module.languageLevel = new org.gradle.plugins.ide.idea.model.IdeaLanguageLevel(14)
+
+def target21Compiler = javaToolchains.compilerFor {
+    it.languageVersion = JavaLanguageVersion.of(21)
 }
+
+def target21Launcher = javaToolchains.launcherFor {
+    it.languageVersion = JavaLanguageVersion.of(21)
+}
+
+
+sourceSets.create("java21") {
+}
+
+sourceSets.create("test21") {
+}
+
+tasks.named("compileJava21Java", JavaCompile) {
+    it.javaCompiler = target21Compiler
+    it.sourceCompatibility = 21
+    it.targetCompatibility = 21
+    it.source = sourceSets.named("java21").get().java
+    it.classpath = project.objects.fileCollection().from(
+            sourceSets.named("main").get().output,
+            sourceSets.named("main").get().compileClasspath,
+            sourceSets.named("java21").get().compileClasspath
+    )
+}
+
+tasks.named("compileTest21Java", JavaCompile) {
+    it.javaCompiler = target21Compiler
+    it.sourceCompatibility = 21
+    it.targetCompatibility = 21
+    it.source = sourceSets.named("test21").get().java
+    it.classpath = sourceSets.named("test").get().runtimeClasspath
+}
+
+tasks.register("testJava21", Test) {
+
+    it.group = "verification"
+    it.javaLauncher.set(target21Launcher.get())
+
+    useJUnitPlatform()
+
+    it.testClassesDirs = project.objects.fileCollection().from(
+            sourceSets.named("test21").get().output.classesDirs
+    )
+    it.classpath = project.objects.fileCollection().from(
+            sourceSets.named("test21").get().output,
+            sourceSets.named("java21").get().output,
+            sourceSets.named("test").get().runtimeClasspath
+    )
+}
+
+
+sourceSets.create("java21Preview") {
+    java.srcDirs(project.layout.projectDirectory.dir("src/java21Preview/java"))
+}
+
+sourceSets.create("test21Preview") {
+    java.srcDirs(project.layout.projectDirectory.dir("src/test21Preview/java"))
+}
+
+tasks.named("compileJava21PreviewJava", JavaCompile) {
+    it.javaCompiler = target21Compiler
+    it.sourceCompatibility = 21
+    it.targetCompatibility = 21
+    options.compilerArgs += '--enable-preview'
+    it.source = sourceSets.named("java21Preview").get().java
+    it.classpath = objects.fileCollection().from(
+            sourceSets.named("main").get().output,
+            sourceSets.named("java21").get().output,
+            sourceSets.named("main").get().compileClasspath,
+            sourceSets.named("java21Preview").get().compileClasspath
+
+    )
+}
+
+tasks.named("compileTest21PreviewJava", JavaCompile) {
+    it.javaCompiler = target21Compiler
+    it.sourceCompatibility = 21
+    it.targetCompatibility = 21
+    options.compilerArgs += '--enable-preview'
+    it.source = sourceSets.named("test21Preview").get().java
+    it.classpath = sourceSets.named("test").get().runtimeClasspath
+}
+
+tasks.register("testJava21Preview", Test) {
+
+    it.group = "verification"
+    it.javaLauncher.set(target21Launcher.get())
+    jvmArgs += '--enable-preview'
+    useJUnitPlatform()
+
+    it.testClassesDirs = project.objects.fileCollection().from(
+            sourceSets.named("test21Preview").get().output.classesDirs
+    )
+    it.classpath = project.objects.fileCollection().from(
+            sourceSets.named("test21Preview").get().output,
+            sourceSets.named("java21Preview").get().output,
+            sourceSets.named("java21").get().output,
+            sourceSets.named("test").get().runtimeClasspath
+    )
+}
+
+tasks.check { dependsOn(test,testJava21,testJava21Preview) }
 
 // This block may be replaced by BaselineExportsExtension exports
 // once https://github.com/gradle/gradle/issues/18824 is resolved.
@@ -88,4 +189,10 @@ tasks.named("jar", Jar) {
     manifest {
         attributes('Add-Exports': exports.join(' '))
     }
+    it.from(
+            sourceSets.named("main").get().output,
+            sourceSets.named("java21").get().output,
+            sourceSets.named("java21Preview").get().output
+    )
+
 }

--- a/palantir-java-format/src/java21/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
+++ b/palantir-java-format/src/java21/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
@@ -1,0 +1,170 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.java.java21;
+
+import com.google.common.collect.Iterables;
+import com.palantir.javaformat.OpsBuilder;
+import com.palantir.javaformat.java.JavaInputAstVisitor;
+import com.palantir.javaformat.java.java14.Java14InputAstVisitor;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ConstantCaseLabelTree;
+import com.sun.source.tree.DeconstructionPatternTree;
+import com.sun.source.tree.ParenthesizedTree;
+import com.sun.source.tree.PatternCaseLabelTree;
+import com.sun.source.tree.PatternTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Extends {@link Java14InputAstVisitor} with support for AST nodes that were added or modified for Java 14.
+ */
+public class Java21InputAstVisitor extends Java14InputAstVisitor {
+    private static final Method CASE_TREE_GET_LABELS2 = maybeGetMethodPrivate(CaseTree.class, "getLabels");
+
+    private static Method maybeGetMethodPrivate(Class<?> c, String name) {
+        try {
+            return c.getMethod(name);
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+
+    private static Object invokePrivate(Method m, Object target) {
+        try {
+            return m.invoke(target);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public Java21InputAstVisitor(OpsBuilder builder, int indentMultiplier) {
+        super(builder, indentMultiplier);
+    }
+
+    @Override
+    public Void visitParenthesized(ParenthesizedTree node, Void unused) {
+        token("(");
+        Void v = scan(node.getExpression(), unused);
+        token(")");
+        return v;
+    }
+
+    @Override
+    public Void visitDeconstructionPattern(DeconstructionPatternTree node, Void unused) {
+
+        Void r = scan(node.getDeconstructor(), unused);
+        token("(");
+        boolean firstInRow = true;
+        for (PatternTree item : node.getNestedPatterns()) {
+            if (!firstInRow) {
+                token(",");
+                builder.breakToFill(" ");
+            }
+            scan(item, null);
+            firstInRow = false;
+        }
+        token(")");
+        return r;
+    }
+
+    @Override
+    public Void visitConstantCaseLabel(ConstantCaseLabelTree node, Void unused) {
+        return scan(node.getConstantExpression(), unused);
+    }
+
+    @Override
+    public Void visitCase(CaseTree node, Void unused) {
+        sync(node);
+        markForPartialFormat();
+        builder.forcedBreak();
+        List<? extends Tree> labels;
+        boolean isDefault;
+        if (CASE_TREE_GET_LABELS2 != null) {
+            labels = (List<? extends Tree>) invokePrivate(CASE_TREE_GET_LABELS2, node);
+            isDefault = labels.size() == 1
+                    && Iterables.getOnlyElement(labels).getKind().name().equals("DEFAULT_CASE_LABEL");
+        } else {
+            labels = node.getExpressions();
+            isDefault = labels.isEmpty();
+        }
+        if (isDefault) {
+            token("default", plusTwo);
+        } else {
+            token("case", plusTwo);
+            builder.space();
+            builder.open(labels.size() > 1 ? plusFour : JavaInputAstVisitor.ZERO);
+            boolean first = true;
+            for (Tree expression : labels) {
+                if (!first) {
+                    token(",");
+                    builder.breakOp(" ");
+                }
+                scan(expression, null);
+                first = false;
+            }
+            builder.close();
+        }
+        switch (node.getCaseKind()) {
+            case STATEMENT:
+                token(":");
+                boolean isBlock = node.getStatements().size() == 1
+                        && node.getStatements().get(0).getKind() == Kind.BLOCK;
+                builder.open(isBlock ? JavaInputAstVisitor.ZERO : plusTwo);
+                if (isBlock) {
+                    builder.space();
+                }
+                visitStatements(node.getStatements(), isBlock);
+                builder.close();
+                break;
+            case RULE:
+                if (node.getGuard() != null) {
+                    builder.space();
+                    token("when");
+                    builder.space();
+                    scan(node.getGuard(), null);
+                }
+
+                builder.space();
+                token("-");
+                token(">");
+
+                builder.space();
+                if (node.getBody().getKind() == Kind.BLOCK) {
+                    // Explicit call with {@link CollapseEmptyOrNot.YES} to handle empty case blocks.
+                    visitBlock(
+                            (BlockTree) node.getBody(),
+                            CollapseEmptyOrNot.YES,
+                            AllowLeadingBlankLine.NO,
+                            AllowTrailingBlankLine.NO);
+                } else {
+                    scan(node.getBody(), null);
+                }
+                builder.guessToken(";");
+                break;
+            default:
+                throw new IllegalArgumentException(node.getCaseKind().name());
+        }
+        return null;
+    }
+
+    public Void visitPatternCaseLabel(PatternCaseLabelTree node, Void p) {
+        return scan(node.getPattern(), p);
+    }
+}

--- a/palantir-java-format/src/java21Preview/java/com/palantir/javaformat/java/java21/Java21PreviewInputAstVisitor.java
+++ b/palantir-java-format/src/java21Preview/java/com/palantir/javaformat/java/java21/Java21PreviewInputAstVisitor.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.javaformat.java.java21;
+
+import com.palantir.javaformat.OpsBuilder;
+import com.sun.source.tree.AnyPatternTree;
+
+public class Java21PreviewInputAstVisitor extends Java21InputAstVisitor {
+
+    public Java21PreviewInputAstVisitor(OpsBuilder builder, int indentMultiplier) {
+        super(builder, indentMultiplier);
+    }
+
+    public Void visitAnyPattern(AnyPatternTree node, Void p) {
+        token("_");
+        return p;
+    }
+}

--- a/palantir-java-format/src/test21/java/com/palantir/javaformat/java/FileBased21Tests.java
+++ b/palantir-java-format/src/test21/java/com/palantir/javaformat/java/FileBased21Tests.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,15 +42,12 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public final class FileBasedTests {
+public final class FileBased21Tests {
     // Test files that are only used when run with a minimum Java version
     private static final ImmutableMultimap<Integer, String> VERSIONED_TESTS =
             ImmutableMultimap.<Integer, String>builder()
-                    .putAll(14, "Records", "RSL", "Var", "ExpressionSwitch", "I574", "I594")
-                    .putAll(15, "I603")
-                    .putAll(16, "I588")
-                    .putAll(17, "I683", "I684", "I696")
-                    // .putAll(21, "I683", "I684", "I696")
+                    // .putAll(21, "I959", "I960", "I961", "I962")
+                    .putAll(21, "I964", "I965")
                     .build();
 
     private final Class<?> testClass;
@@ -59,22 +56,23 @@ public final class FileBasedTests {
     /** Where to output test outputs when recreating. */
     private final Path fullTestPath;
 
-    public FileBasedTests(Class<?> testClass) {
+    public FileBased21Tests(Class<?> testClass) {
         this(testClass, testClass.getSimpleName());
     }
 
-    public FileBasedTests(Class<?> testClass, String testDirName) {
+    public FileBased21Tests(Class<?> testClass, String testDirName) {
         this.resourcePrefix =
                 Paths.get(testClass.getPackage().getName().replace('.', '/')).resolve(testDirName);
         this.testClass = testClass;
-        this.fullTestPath = Paths.get("src/test/resources").resolve(resourcePrefix);
+        this.fullTestPath = Paths.get("src/test21/resources").resolve(resourcePrefix);
+        System.out.println(this.fullTestPath.normalize().toAbsolutePath().toString());
     }
 
     public static void assumeJavaVersionForTest(String testName) {
         Optional<Integer> maybeJavaVersion =
                 VERSIONED_TESTS.inverse().get(testName).stream().collect(toOptional());
         maybeJavaVersion.ifPresent(version -> Assumptions.assumeTrue(
-                Formatter.getRuntimeVersion() >= version, String.format("Not running on jdk %d or later", version)));
+                Runtime.version().feature() >= version, String.format("Not running on jdk %d or later", version)));
     }
 
     public List<Object[]> paramsAsNameInputOutput() throws IOException {

--- a/palantir-java-format/src/test21/java/com/palantir/javaformat/java/FormatterIntegration21Test.java
+++ b/palantir-java-format/src/test21/java/com/palantir/javaformat/java/FormatterIntegration21Test.java
@@ -1,0 +1,138 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.java;
+
+import static com.palantir.javaformat.java.FileBased21Tests.assumeJavaVersionForTest;
+import static com.palantir.javaformat.java.FileBased21Tests.isRecreate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.javaformat.Newlines;
+import com.palantir.javaformat.jupiter.ParameterizedClass;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@ExtendWith(ParameterizedClass.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class FormatterIntegration21Test {
+
+    private static FileBased21Tests tests = new FileBased21Tests(FormatterIntegration21Test.class, "testdata21");
+
+    @ParameterizedClass.Parameters(name = "{0}")
+    public static List<Object[]> data() throws IOException {
+        return tests.paramsAsNameInputOutput();
+    }
+
+    private final String name;
+    private final String input;
+    private final String expected;
+    private final String separator;
+
+    public FormatterIntegration21Test(String name, String input, String expected) {
+        this.name = name;
+        this.input = input;
+        this.expected = expected;
+        this.separator = isRecreate() ? null : Newlines.getLineEnding(expected);
+    }
+
+    /**
+     * If enabled, then {@link DebugRenderer} will produce an output at {@link DebugRenderer#getOutputFile()}. This can
+     * then be viewed in a browser by running the following once (after which it will auto-reload whenever the debug
+     * output file changes):
+     *
+     * <pre>
+     * cd debugger
+     * yarn start
+     * </pre>
+     *
+     * <p>Warning: don't turn this on for all tests. The debugger will always write to the same file.
+     */
+    private static boolean isDebugMode() {
+        return Boolean.getBoolean("debugOutput");
+    }
+
+    @TestTemplate
+    public void format() {
+        assumeJavaVersionForTest(name);
+        try {
+            String output = createFormatter().formatSource(input);
+            Files.writeString(Path.of("/tmp/" + name + ".output"), output);
+            if (isRecreate()) {
+                tests.writeFormatterOutput(name, output);
+                return;
+            }
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(expected);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Formatter createFormatter() {
+        return new Formatter(
+                JavaFormatterOptions.builder()
+                        .style(JavaFormatterOptions.Style.PALANTIR)
+                        .build(),
+                isDebugMode());
+    }
+
+    //  @TestTemplate
+    public void idempotentLF() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\n");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+
+    // @TestTemplate
+    public void idempotentCR() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\r");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+
+    @TestTemplate
+    public void idempotentCRLF() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\r\n");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+}

--- a/palantir-java-format/src/test21/resources/com/palantir/javaformat/java/testdata21/I964.input
+++ b/palantir-java-format/src/test21/resources/com/palantir/javaformat/java/testdata21/I964.input
@@ -1,0 +1,23 @@
+
+public class I964 {
+
+  record Point(int x, int y) {}
+
+  public static void printSum(Object obj) {
+      if (obj instanceof Point p) {
+          int x = p.x();
+          int y = p.y();
+          System.out.println(x+y);
+      }
+  }
+
+  public void JEP440(Object obj){
+
+    if (obj instanceof Point(int x, int y)) {
+            System.out.println(x+y);
+     }
+
+   }
+
+
+}

--- a/palantir-java-format/src/test21/resources/com/palantir/javaformat/java/testdata21/I964.output
+++ b/palantir-java-format/src/test21/resources/com/palantir/javaformat/java/testdata21/I964.output
@@ -1,0 +1,19 @@
+public class I964 {
+
+    record Point(int x, int y) {}
+
+    public static void printSum(Object obj) {
+        if (obj instanceof Point p) {
+            int x = p.x();
+            int y = p.y();
+            System.out.println(x + y);
+        }
+    }
+
+    public void JEP440(Object obj) {
+
+        if (obj instanceof Point(int x, int y)) {
+            System.out.println(x + y);
+        }
+    }
+}

--- a/palantir-java-format/src/test21Preview/java/com/palantir/javaformat/java/FileBased21PreviewTests.java
+++ b/palantir-java-format/src/test21Preview/java/com/palantir/javaformat/java/FileBased21PreviewTests.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,15 +42,12 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
-public final class FileBasedTests {
+public final class FileBased21PreviewTests {
     // Test files that are only used when run with a minimum Java version
     private static final ImmutableMultimap<Integer, String> VERSIONED_TESTS =
             ImmutableMultimap.<Integer, String>builder()
-                    .putAll(14, "Records", "RSL", "Var", "ExpressionSwitch", "I574", "I594")
-                    .putAll(15, "I603")
-                    .putAll(16, "I588")
-                    .putAll(17, "I683", "I684", "I696")
-                    // .putAll(21, "I683", "I684", "I696")
+                    // .putAll(21, "I959", "I960", "I961", "I962")
+                    .putAll(21, "I964", "I965")
                     .build();
 
     private final Class<?> testClass;
@@ -59,22 +56,23 @@ public final class FileBasedTests {
     /** Where to output test outputs when recreating. */
     private final Path fullTestPath;
 
-    public FileBasedTests(Class<?> testClass) {
+    public FileBased21PreviewTests(Class<?> testClass) {
         this(testClass, testClass.getSimpleName());
     }
 
-    public FileBasedTests(Class<?> testClass, String testDirName) {
+    public FileBased21PreviewTests(Class<?> testClass, String testDirName) {
         this.resourcePrefix =
                 Paths.get(testClass.getPackage().getName().replace('.', '/')).resolve(testDirName);
         this.testClass = testClass;
-        this.fullTestPath = Paths.get("src/test/resources").resolve(resourcePrefix);
+        this.fullTestPath = Paths.get("src/test21Preview/resources").resolve(resourcePrefix);
+        System.out.println(this.fullTestPath.normalize().toAbsolutePath().toString());
     }
 
     public static void assumeJavaVersionForTest(String testName) {
         Optional<Integer> maybeJavaVersion =
                 VERSIONED_TESTS.inverse().get(testName).stream().collect(toOptional());
         maybeJavaVersion.ifPresent(version -> Assumptions.assumeTrue(
-                Formatter.getRuntimeVersion() >= version, String.format("Not running on jdk %d or later", version)));
+                Runtime.version().feature() >= version, String.format("Not running on jdk %d or later", version)));
     }
 
     public List<Object[]> paramsAsNameInputOutput() throws IOException {

--- a/palantir-java-format/src/test21Preview/java/com/palantir/javaformat/java/FormatterIntegration21PreviewTest.java
+++ b/palantir-java-format/src/test21Preview/java/com/palantir/javaformat/java/FormatterIntegration21PreviewTest.java
@@ -1,0 +1,139 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.java;
+
+import static com.palantir.javaformat.java.FileBased21PreviewTests.assumeJavaVersionForTest;
+import static com.palantir.javaformat.java.FileBased21PreviewTests.isRecreate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.javaformat.Newlines;
+import com.palantir.javaformat.jupiter.ParameterizedClass;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@ExtendWith(ParameterizedClass.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class FormatterIntegration21PreviewTest {
+
+    private static FileBased21PreviewTests tests =
+            new FileBased21PreviewTests(FormatterIntegration21PreviewTest.class, "testdata21Preview");
+
+    @ParameterizedClass.Parameters(name = "{0}")
+    public static List<Object[]> data() throws IOException {
+        return tests.paramsAsNameInputOutput();
+    }
+
+    private final String name;
+    private final String input;
+    private final String expected;
+    private final String separator;
+
+    public FormatterIntegration21PreviewTest(String name, String input, String expected) {
+        this.name = name;
+        this.input = input;
+        this.expected = expected;
+        this.separator = isRecreate() ? null : Newlines.getLineEnding(expected);
+    }
+
+    /**
+     * If enabled, then {@link DebugRenderer} will produce an output at {@link DebugRenderer#getOutputFile()}. This can
+     * then be viewed in a browser by running the following once (after which it will auto-reload whenever the debug
+     * output file changes):
+     *
+     * <pre>
+     * cd debugger
+     * yarn start
+     * </pre>
+     *
+     * <p>Warning: don't turn this on for all tests. The debugger will always write to the same file.
+     */
+    private static boolean isDebugMode() {
+        return Boolean.getBoolean("debugOutput");
+    }
+
+    @TestTemplate
+    public void format() {
+        assumeJavaVersionForTest(name);
+        try {
+            String output = createFormatter().formatSource(input);
+            Files.writeString(Path.of("/tmp/" + name + ".output"), output);
+            if (isRecreate()) {
+                tests.writeFormatterOutput(name, output);
+                return;
+            }
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(expected);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Formatter createFormatter() {
+        return new Formatter(
+                JavaFormatterOptions.builder()
+                        .style(JavaFormatterOptions.Style.PALANTIR)
+                        .build(),
+                isDebugMode());
+    }
+
+    //  @TestTemplate
+    public void idempotentLF() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\n");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+
+    // @TestTemplate
+    public void idempotentCR() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\r");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+
+    @TestTemplate
+    public void idempotentCRLF() {
+        assumeJavaVersionForTest(name);
+        Assumptions.assumeFalse(isRecreate(), "Not running when recreating test outputs");
+        try {
+            String mangled = expected.replace(separator, "\r\n");
+            String output = createFormatter().formatSource(mangled);
+            assertThat(output).describedAs("bad output for " + name).isEqualTo(mangled);
+        } catch (FormatterException e) {
+            throw new RuntimeException(String.format("Formatter crashed on %s", name), e);
+        }
+    }
+}

--- a/palantir-java-format/src/test21Preview/resources/com/palantir/javaformat/java/testdata21Preview/I963.input
+++ b/palantir-java-format/src/test21Preview/resources/com/palantir/javaformat/java/testdata21Preview/I963.input
@@ -1,0 +1,15 @@
+
+public class I964 {
+
+  record Point(int x, int y) {}
+
+  public void JEP395(Object obj){
+
+    if (obj instanceof Point(int x, _)) {
+           System.out.println(x);
+     }
+     
+   }
+
+
+}

--- a/palantir-java-format/src/test21Preview/resources/com/palantir/javaformat/java/testdata21Preview/I963.output
+++ b/palantir-java-format/src/test21Preview/resources/com/palantir/javaformat/java/testdata21Preview/I963.output
@@ -1,0 +1,11 @@
+public class I964 {
+
+    record Point(int x, int y) {}
+
+    public void JEP395(Object obj) {
+
+        if (obj instanceof Point(int x, _)) {
+            System.out.println(x);
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
May error on parsing Java 21 file.

## After this PR
Support of different JEP of Java 21 and preview
- JEP-430 StringTemplates
- JEP-440 Record Patterns
- JEP-441 Pattern Matching switch (with guard) 
- JEP-443 Unamed Pattern

## Possible downsides?

### Build 
- I added a independent gradle module to build all Java 21 code but the gradle do not support to build groovy code with java 21: it should be first compile with java 17 and you can compile the project with java 21 😞
- I added a hack on palantir-java-format gradle script to copy all the java 21 class file on the jar. 😞
- Need to  add --enable-preview with Java 21.

### Code
- "StringTemplates" was really hard to support:  I did some change on `JavaInput.java` and `visitStringTemplate`. The complexity of this part is really to high.
- I copy and past "visitCase" from Java14 file and the guard param.


