### PR TITLE
Add emacs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ When enabled, it will replace the normal `Reformat Code` action, which can be
 triggered from the `Code` menu or with the Ctrl-Alt-L (by default) keyboard
 shortcut.
 
+## Emacs plugin
+
+An Emacs plugin is included in this repository. To use it, load [palantir-java-style.el](https://github.com/palantir/palantir-java-format/blob/develop/emacs-plugin/palantir-java-style.el). Afterwards, you can switch to the style for any Java file with <kbd>C-c</kbd> <kbd>.</kbd> `palantir`. See [Choosing a Style](https://www.gnu.org/software/emacs/manual/html_node/ccmode/Choosing-a-Style.html) to make it the default style.
+
 ## Future works
 
 - [ ] preserve [NON-NLS markers][] - these are comments that are used when implementing NLS internationalisation, and need to stay on the same line with the strings they come after.

--- a/changelog/@unreleased/pr-941.v2.yml
+++ b/changelog/@unreleased/pr-941.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add emacs plugin
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/941

--- a/emacs-plugin/palantir-java-style.el
+++ b/emacs-plugin/palantir-java-style.el
@@ -1,0 +1,48 @@
+;;; palantir-java-style.el --- Indentation style matching palantir-java-format -*- lexical-binding: t -*-
+
+;; Author: Will Dey
+;; Maintainer: Will Dey
+;; Version: 1.0.0
+;; Package-Requires: ()
+;; Homepage: https://github.com/palantir/palantir-java-format
+
+;; This file is not part of GNU Emacs
+
+;;; Code:
+
+;;;###autoload
+(defun palantir-java-style-lineup-anchor (langelem)
+  (vector (c-langelem-col langelem :preserve-point)))
+
+(defvar c-syntactic-context)
+;;;###autoload
+(defun palantir-java-style-lineup-single-arg (_langelem)
+  (save-excursion
+    (forward-line)
+    (when (assq 'statement-cont (c-guess-basic-syntax))
+      '++)))
+
+;;;###autoload
+(defun palantir-java-style-lineup-cascaded-calls (langelem)
+  (save-excursion
+    (back-to-indentation)
+    (when (looking-at (rx ?.))
+      '++)))
+
+;;;###autoload
+(defconst palantir-java-style
+  '("java"
+    (indent-tabs-mode . nil)
+    (c-basic-offset . 4)
+    (c-offsets-alist . ((statement-cont . ++)
+			(arglist-cont . (first palantir-java-style-lineup-cascaded-calls 0))
+			(arglist-intro . (add palantir-java-style-lineup-anchor ++ palantir-java-style-lineup-single-arg))
+			(arglist-cont-nonempty . ++)
+			(template-args-cont . 16)))))
+
+;;;###autoload
+(c-add-style "palantir" palantir-java-style)
+
+(provide 'palantir-java-style)
+
+;;; palantir-java-style.el ends here

--- a/emacs-plugin/palantir-java-style.el
+++ b/emacs-plugin/palantir-java-style.el
@@ -10,6 +10,8 @@
 
 ;;; Code:
 
+(require 'rx)
+
 ;;;###autoload
 (defun palantir-java-style-lineup-anchor (langelem)
   (vector (c-langelem-col langelem :preserve-point)))

--- a/emacs-plugin/palantir-java-style.el
+++ b/emacs-plugin/palantir-java-style.el
@@ -23,7 +23,7 @@
       '++)))
 
 ;;;###autoload
-(defun palantir-java-style-lineup-cascaded-calls (langelem)
+(defun palantir-java-style-lineup-cascaded-calls (_langelem)
   (save-excursion
     (back-to-indentation)
     (when (looking-at (rx ?.))


### PR DESCRIPTION
## Before this PR
No Emacs plugin and the default "java" indentation format would indent code very differently than the Palantir formatter, especially when using `aggressive-indent-mode`.

## After this PR
Added a style which matches the Palantir indentation very closely. It won't rewrap code or do any more-involved reformatting, but it will be able to keep code indented the same.

==COMMIT_MSG==
Add emacs plugin
==COMMIT_MSG==

## Possible downsides?
None

