### PR TITLE
Fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,5 +8,5 @@ Clear steps to reproduce the behaviour are always helpful too!
 ## What did you want to happen?
 
 <!--
-Suggest better behaviour
+Suggest better behavior
 -->


### PR DESCRIPTION
## Before this PR

Spell checker complained about American English vs. British English

![image](https://github.com/palantir/palantir-java-format/assets/1366654/ac134461-6ad4-4c9c-9972-be100518945e)

Is the checker right?

## After this PR

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix typo in ISSUE_TEMPLATE.md
==COMMIT_MSG==


