### PR TITLE
Switch to Java 21 for compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
 jobs:
 
   check:
-    docker: [{ image: 'cimg/openjdk:17.0.1-node' }]
+    docker: [{ image: 'cimg/openjdk:11.0.21-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,11 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'org.inferred.processors'
 
-    sourceCompatibility = 11
-    targetCompatibility = 11
+    java {
+      toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+      }
+    }
 
     tasks.withType(Checkstyle) {
         enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ allprojects {
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
     }
+    pluginManager.withPlugin('java') {
+        tasks.withType(JavaCompile) {
+            options.errorprone {
+                enabled = false
+            }
+        }
+    }
 }
 
 subprojects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,17 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver") version "0.7.0"
+}
+
+toolchainManagement {
+    jvm {
+        javaRepositories {
+            repository("foojay") {
+                resolverClass = org.gradle.toolchains.foojay.FoojayToolchainResolver
+            }
+        }
+    }
+}
+
 rootProject.name = 'palantir-java-format-parent'
 
 include ':gradle-palantir-java-format'


### PR DESCRIPTION
## Before this PR

palantir-java-format relied on Java 11 for compilation.

Gradle update does not work. See https://github.com/palantir/palantir-java-format/issues/977.

## After this PR

palantir-java-format relias on Java 21 for compilation, but sticks with Gradle 7.6.2.

This enables working on Java 21 related tickets.

## Possible downsides?

Java 21 might be a too strong requirement for some "legacy" code. One could release `3.0.0` and say, hey, 2.x supports up to Java 20, 3.x supports 21+.

