### PR TITLE
Cleanup Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,17 +49,17 @@ subprojects {
     sourceCompatibility = 11
     targetCompatibility = 11
 
-    tasks.withType(Checkstyle) {
+    tasks.withType(Checkstyle).configureEach {
         enabled = false
     }
 
-    tasks.withType(JavaCompile) {
+    tasks.withType(JavaCompile).configureEach {
         options.errorprone.disable 'PreconditionsConstantMessage', 'PreferSafeLoggableExceptions', 'PreferSafeLoggingPreconditions'
     }
 
     // Run `./gradlew test -Drecreate=true` to recreate all the expected
     // generated code that we have checked into the repo.
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         systemProperty 'recreate', System.getProperty('recreate', 'false')
     }
 }

--- a/eclipse_plugin/build.gradle
+++ b/eclipse_plugin/build.gradle
@@ -29,17 +29,15 @@ dependencies {
     implementation project(':palantir-java-format')
 }
 
-jar {
+tasks.named("jar", Jar) {
     archiveBaseName = 'palantir-java-format-eclipse-plugin'
     manifest {
         from 'src/main/resources/META-INF/MANIFEST.MF'
     }
     // We embed some dependencies into the JAR file
-    from(configurations.runtimeClasspath.filter {
-        var name = it.getName()
-        name.startsWith('functionaljava') || name.startsWith('guava') || name.startsWith('palantir')
-    }) {
+    from(configurations.runtimeClasspath) {
         into 'lib'
+        include('functionaljava*', 'guava*', 'palantir*')
         // The libraries are listed without a version in the manifest
         rename('(.*)-[0-9b.]+(\\.dirty|-jre)?\\.jar', '$1.jar')
     }

--- a/gradle-palantir-java-format/build.gradle
+++ b/gradle-palantir-java-format/build.gradle
@@ -4,12 +4,9 @@ apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 apply plugin: 'com.palantir.revapi'
 
-configurations {
-    implicitDependencies
-    pluginClasspath
-}
-
 dependencies {
+    compileOnly 'com.diffplug.spotless:spotless-plugin-gradle'
+
     implementation gradleApi()
     implementation 'com.google.guava:guava'
     implementation project(':palantir-java-format-spi')
@@ -21,75 +18,61 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation project(':palantir-java-format')
 
-    // Have to configure this manually in order to resolve the implicitDependencies together with runtimeClasspath
-    // This is to allow both our code and spotless to end up on the same class loader in tests.
-    // Ordinarily when running, these would end up on the same classloader
-    pluginClasspath configurations.implicitDependencies
-    pluginClasspath configurations.runtimeClasspath
-    pluginClasspath sourceSets.main.output
-    compileOnly configurations.implicitDependencies
-    implicitDependencies 'com.diffplug.spotless:spotless-plugin-gradle'
+    testRuntimeOnly 'com.diffplug.spotless:spotless-plugin-gradle'
 }
 
 gradlePlugin {
+    website = 'https://github.com/palantir/palantir-java-format/'
+    vcsUrl = 'https://github.com/palantir/palantir-java-format/'
     plugins {
         palantirJavaFormat {
             id = 'com.palantir.java-format'
             implementationClass = 'com.palantir.javaformat.gradle.PalantirJavaFormatPlugin'
             description = 'A modern, lambda-friendly, 120 character Java formatter. Applies all other palantir-java-format plugins.'
             displayName = 'Palantir Java Format'
+            tags.set(['java', 'style'])
         }
         palantirJavaFormatIdea {
             id = 'com.palantir.java-format-idea'
             implementationClass = 'com.palantir.javaformat.gradle.PalantirJavaFormatIdeaPlugin'
             description = 'Plugin to configure the PalantirJavaFormat IDEA plugin based on an optional implementation version of the formatter.'
             displayName = 'Palantir Java Format Idea'
+            tags.set(['java', 'style'])
         }
         palantirJavaFormatSpotless {
             id = 'com.palantir.java-format-spotless'
             implementationClass = 'com.palantir.javaformat.gradle.PalantirJavaFormatSpotlessPlugin'
             description = 'If spotless is applied, configures a java step that formats using palantir-java-format.'
             displayName = 'Palantir Java Format Spotless'
+            tags.set(['java', 'style'])
         }
         palantirJavaFormatProvider {
             id = 'com.palantir.java-format-provider'
             implementationClass = 'com.palantir.javaformat.gradle.PalantirJavaFormatProviderPlugin'
             description = 'Exposes a configuration containing the palantir-java-format jars'
             displayName = 'Palantir Java Format Provider'
+            tags.set(['java', 'style'])
         }
     }
 }
 
-pluginBundle {
-    website = 'https://github.com/palantir/palantir-java-format/'
-    vcsUrl = 'https://github.com/palantir/palantir-java-format/'
-    description = 'Palantir Java Format is an opinionated lambda friendly formatter for java.'
-    tags = ['java', 'style']
-}
-
-tasks.withType(PluginUnderTestMetadata) {
-    pluginClasspath.from = configurations.pluginClasspath
-}
-
-idea {
-    module {
-        sourceDirs += sourceSets.main.groovy.srcDirs
-    }
-}
-
 configurations {
-    impl
+    impl {
+        canBeConsumed = false
+        canBeResolved = true
+    }
 }
 
 dependencies {
     impl project(':palantir-java-format')
 }
 
-task writeImplClasspath {
-    dependsOn configurations.impl
+def writeImplClasspath = tasks.register("writeImplClasspath") {
     doLast {
         file("$buildDir/impl.classpath").text = configurations.impl.asPath
     }
 }
 
-test.dependsOn tasks.writeImplClasspath
+tasks.named("test").configure {
+    dependsOn(writeImplClasspath)
+}

--- a/gradle-palantir-java-format/build.gradle
+++ b/gradle-palantir-java-format/build.gradle
@@ -4,6 +4,13 @@ apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 apply plugin: 'com.palantir.revapi'
 
+configurations {
+    pluginClasspath {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
 dependencies {
     compileOnly 'com.diffplug.spotless:spotless-plugin-gradle'
 
@@ -18,7 +25,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation project(':palantir-java-format')
 
-    testRuntimeOnly 'com.diffplug.spotless:spotless-plugin-gradle'
+    pluginClasspath 'com.diffplug.spotless:spotless-plugin-gradle'
 }
 
 gradlePlugin {
@@ -54,6 +61,10 @@ gradlePlugin {
             tags.set(['java', 'style'])
         }
     }
+}
+
+tasks.withType(PluginUnderTestMetadata).configureEach {
+    pluginClasspath.from += configurations.pluginClasspath
 }
 
 configurations {

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -27,9 +27,13 @@ intellij {
     plugins = ['java']
 }
 
-tasks.runIde {
+def buildPlugin = tasks.named("buildPlugin")
+
+tasks.named("runIde") {
     // Allow debugging
     jvmArgs '--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED'
+
+    dependsOn(buildPlugin)
 }
 
 patchPluginXml {
@@ -39,15 +43,21 @@ patchPluginXml {
     untilBuild = ''
 }
 
-publishPlugin {
+def publishPlugin = tasks.named("publishPlugin") {
+    onlyIf { versionDetails().isCleanTag }
+
     token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
 }
-tasks.publishPlugin.onlyIf { versionDetails().isCleanTag }
-tasks.publish.dependsOn publishPlugin
+tasks.named("publish") {
+    dependsOn(publishPlugin)
+}
 
 configurations {
     formatter {
         description = 'The default implementation of palantir-java-format, used if the user doesn\'t specify an explicit classpath.'
+
+        canBeConsumed = false
+        canBeResolved = true
     }
 }
 
@@ -73,11 +83,13 @@ tasks.withType(JavaCompile).configureEach {
     options.errorprone.disable 'PreferSafeLoggingPreconditions'
 }
 
-check.dependsOn buildPlugin, verifyPlugin
+tasks.named("check") {
+    dependsOn(buildPlugin, tasks.named("verifyPlugin"))
+}
 // This task will resolve runtimeClasspath without telling Gradle that it depends on it, therefore dependent jars won't
 // be created beforehand. Therefore, ensure that it knows about it.
 // see https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/groovy/org/jetbrains/intellij/tasks/PrepareSandboxTask.groovy
-tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask) {
+tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask).configureEach {
     dependsOn configurations.runtimeClasspath
 
     // Also pack the formatter in its own directory
@@ -88,9 +100,9 @@ tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask) {
     }
 }
 
-runIde.dependsOn buildPlugin
-
-buildSearchableOptions.enabled = false
+tasks.named("buildSearchableOptions") {
+    enabled = false
+}
 
 // Prevent nebula.maven-publish from trying to publish components.java - we are publishing our own different artifact
 ext."nebulaPublish.maven.jar" = false
@@ -109,4 +121,6 @@ versionsLock {
 }
 
 // Javadoc fails if there are no public classes to javadoc, so make it stop complaining.
-tasks.javadoc.failOnError = false
+tasks.named("javadoc", Javadoc) {
+    failOnError = false
+}

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -1,6 +1,3 @@
-import java.util.function.Function
-import java.util.stream.Collectors
-
 apply plugin: 'application'
 apply plugin: 'com.palantir.external-publish-jar'
 
@@ -43,12 +40,7 @@ def exports = [
         'jdk.compiler/com.sun.tools.javac.api'
 ]
 
-def jvmArgList = exports.stream().map(new Function<String, String>() {
-    @Override
-    String apply(String value) {
-        return "--add-exports=${value}=ALL-UNNAMED"
-    }
-}).collect(Collectors.toList())
+def jvmArgList = exports.collect { value -> "--add-exports=${value}=ALL-UNNAMED".toString() }
 
 tasks.withType(JavaCompile).configureEach {
     options.errorprone.disable 'StrictUnusedVariable'
@@ -75,9 +67,11 @@ tasks.withType(Javadoc).configureEach {
 }
 
 // false positives due to org.junit.runners.* in the test cases
-tasks.checkJUnitDependencies.enabled = false
+tasks.named("checkJUnitDependencies") {
+    enabled = false
+}
 
-tasks.test {
+tasks.named("test") {
     // Run all classes and tests in parallel
     // https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution
     systemProperty 'junit.jupiter.execution.parallel.mode.default', 'concurrent'
@@ -90,8 +84,8 @@ idea {
 
 // This block may be replaced by BaselineExportsExtension exports
 // once https://github.com/gradle/gradle/issues/18824 is resolved.
-jar {
+tasks.named("jar", Jar) {
     manifest {
-        attributes('Add-Exports': exports.stream().collect(Collectors.joining(' ')))
+        attributes('Add-Exports': exports.join(' '))
     }
 }


### PR DESCRIPTION
## Before this PR
The build was using some old patterns that aren't supported anymore preventing Gradle 8.x adoption.


## After this PR
* Fixes the current Gradle build at least partially to be compatible with Gradle 8.x
* Improves the configuration phase by avoiding creating any tasks or resolving any dependencies
* There still remains an issue that can't be resolved as it's upstream in the Intellij plugin which is supposed to be fixed in 2.0 whenever it gets released. https://github.com/JetBrains/gradle-intellij-plugin/issues/1494


## Possible downsides?
None.