### PR TITLE
Upgrade to Gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "1.3.0" apply false
-    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
+    id "org.jetbrains.intellij" version "1.13.2" apply false
+    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.7"
 }
 
 apply plugin: 'com.palantir.external-publish'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Bump Intellij plugins (I get a compilation error otherwise)
- Bump gradle wrapper to v8.5

Seems to work for me?

```
❯ cd ~/src/github.com/palantir/palantir-java-format

❯ java -version
openjdk version "21" 2023-09-19 LTS
OpenJDK Runtime Environment Temurin-21+35 (build 21+35-LTS)
OpenJDK 64-Bit Server VM Temurin-21+35 (build 21+35-LTS, mixed mode)

❯ gradle -version
------------------------------------------------------------
Gradle 8.5
------------------------------------------------------------

Build time:   2023-11-29 14:08:57 UTC
Revision:     28aca86a7180baa17117e0e5ba01d8ea9feca598

Kotlin:       1.9.20
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          21 (Eclipse Adoptium 21+35-LTS)
OS:           Mac OS X 14.3 aarch64

❯ gradle spotlessApply

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 532ms
15 actionable tasks: 15 up-to-date
```