### PR TITLE
Avoid computing expensive debug info for all checkState() calls

### DIFF
--- a/changelog/@unreleased/pr-1029.v2.yml
+++ b/changelog/@unreleased/pr-1029.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid computing expensive debug info for all checkState() calls
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1029

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/CountWidthUntilBreakVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/CountWidthUntilBreakVisitor.java
@@ -16,7 +16,6 @@
 
 package com.palantir.javaformat.doc;
 
-import com.google.common.base.Preconditions;
 import com.palantir.javaformat.PartialInlineability;
 import com.palantir.javaformat.doc.StartsWithBreakVisitor.Result;
 import java.util.List;
@@ -69,10 +68,13 @@ class CountWidthUntilBreakVisitor implements DocVisitor<Float> {
             return visit(level.getDocs().get(found.getAsInt()));
         }
         // Otherwise, assert that we encountered a break and move on.
-        Preconditions.checkState(
-                StartsWithBreakVisitor.INSTANCE.visit(level) == Result.YES,
-                "Didn't find expected break at the beginning of level.\n%s",
-                level.representation(State.startingState()));
+        if (StartsWithBreakVisitor.INSTANCE.visit(level) != Result.YES) {
+            // Avoid computing expensive level.representation() if we aren't throwing it in an exception.
+            throw new IllegalStateException(String.format(
+                    "Didn't find expected break at the beginning of level.\n%s",
+                    level.representation(State.startingState())));
+        }
+
         return 0f;
     }
 


### PR DESCRIPTION
## Before this PR
`level.representation(State.startingState())` is always calculated, regardless of if the `checkState()` check fails.  This is expensive to compute, so we should avoid doing it unless necessary.

![Screenshot 2024-03-13 at 12 33 14 AM](https://github.com/palantir/palantir-java-format/assets/357170/123f1e07-31d1-4b3f-af15-3df1ae40132a)


## After this PR
==COMMIT_MSG==
Avoid computing expensive debug info for all checkState() calls
==COMMIT_MSG==

## Possible downsides?
None known