### PR TITLE
Fix error message link for filing bugs

### DIFF
--- a/changelog/@unreleased/pr-1037.v2.yml
+++ b/changelog/@unreleased/pr-1037.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix error message link for filing bugs
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1037

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
@@ -83,7 +83,7 @@ public final class StringWrapper {
             if (!expected.equals(actual)) {
                 throw new FormatterException(String.format(
                         "Something has gone terribly wrong. Please file a bug: "
-                                + "https://github.com/google/google-java-format/issues/new"
+                                + "https://github.com/palantir/palantir-java-format/issues/new"
                                 + "\n\n=== Actual: ===\n%s\n=== Expected: ===\n%s\n",
                         actual, expected));
             }


### PR DESCRIPTION
## Before this PR
Users see this error message and are urged to file bugs on the wrong repo.  Palantir forked this repo significantly enough that we probably shouldn't be sending bug reports Google's way.

## After this PR
==COMMIT_MSG==
Fix error message link for filing bugs
==COMMIT_MSG==

## Possible downsides?
None known