### PR TITLE
Add shadowJar for generating all-deps jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ generated_src/
 generated_testSrc/
 generated/
 
+# VSCode
+.vscode/
+
 # Blueprint theme
 __init__.pyc
 

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'java'
+}
+
 apply plugin: 'application'
 apply plugin: 'com.palantir.external-publish-jar'
 
@@ -87,5 +92,14 @@ idea {
 tasks.named("jar", Jar) {
     manifest {
         attributes('Add-Exports': exports.join(' '))
+    }
+}
+
+shadowJar {
+    archiveBaseName.set('palantir-java-format')
+    archiveClassifier.set('all-deps')
+    minimize()
+    manifest {
+        attributes 'Main-Class': 'com.palantir.javaformat.java.Main'
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

There is no all-deps jar created. People raise issues like this: https://github.com/palantir/palantir-java-format/issues/902

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

We can run `./gradlew shadowJar` to generate all-deps jar.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

None

