### PR TITLE
Fix: Properly format switch expressions

### DIFF
--- a/changelog/@unreleased/pr-1069.v2.yml
+++ b/changelog/@unreleased/pr-1069.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Properly format switch expressions
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1069

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/FormatDiffTest.java
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/FormatDiffTest.java
@@ -63,6 +63,7 @@ class FormatDiffTest {
         runCommandInRepo("git", "init");
         runCommandInRepo("git", "config", "user.name", "Test User");
         runCommandInRepo("git", "config", "user.email", "test-user@palantir.com");
+        runCommandInRepo("git", "config", "commit.gpgsign", "false");
         runCommandInRepo("git", "commit", "--allow-empty", "-m", "Init");
 
         Path subdir = repo.resolve("subdir");

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -303,6 +303,7 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
                     scan(node.getBody(), null);
                 }
                 builder.guessToken(";");
+                builder.forcedBreak(minusTwo);
                 break;
             default:
                 throw new IllegalArgumentException(node.getCaseKind().name());

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -41,4 +41,21 @@ class ExpressionSwitch {
       default -> false;
     };
   }
+
+  public void test1(int y) {
+      int x =
+              switch (y) {
+                  case 1 -> 1;
+                  case 2 -> throw new IllegalArgumentException();
+                  default -> throw new IllegalStateException();
+              };
+  }
+
+  public void test2(int y) {
+      int x;
+      x = switch (y) {
+          case 1 -> 1;
+          case 2 -> throw new IllegalArgumentException();
+          default -> throw new IllegalStateException();};
+  }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
@@ -47,4 +47,22 @@ class ExpressionSwitch {
             default -> false;
         };
     }
+
+    public void test1(int y) {
+        int x =
+                switch (y) {
+                    case 1 -> 1;
+                    case 2 -> throw new IllegalArgumentException();
+                    default -> throw new IllegalStateException();
+                };
+    }
+
+    public void test2(int y) {
+        int x;
+        x = switch (y) {
+            case 1 -> 1;
+            case 2 -> throw new IllegalArgumentException();
+            default -> throw new IllegalStateException();
+        };
+    }
 }


### PR DESCRIPTION
## Before this PR
Fixes https://github.com/palantir/palantir-java-format/issues/1025 where before this change, we'd format switch expressions used in an assignment to yield the following:
```java
    public void test2(int y) {
        int x;
        x = switch (y) {
            case 1 -> 1;
            case 2 -> throw new IllegalArgumentException();
            default -> throw new IllegalStateException();};
    }
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Properly format switch expressions
==COMMIT_MSG==
and now we generate this:
```java
    public void test2(int y) {
        int x;
        x = switch (y) {
            case 1 -> 1;
            case 2 -> throw new IllegalArgumentException();
            default -> throw new IllegalStateException();
        };
    }
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

