### PR TITLE
Removing Feature.AD_HOC_FORMATTING from PalantirJavaFormatFormattingService

### DIFF
--- a/changelog/@unreleased/pr-1083.v2.yml
+++ b/changelog/@unreleased/pr-1083.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Remove AD_HOC_FORMATTING
+  description: Removing Feature.AD_HOC_FORMATTING from FormattingService
   links:
   - https://github.com/palantir/palantir-java-format/pull/1083

--- a/changelog/@unreleased/pr-1083.v2.yml
+++ b/changelog/@unreleased/pr-1083.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove AD_HOC_FORMATTING
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1083

--- a/changelog/@unreleased/pr-1083.v2.yml
+++ b/changelog/@unreleased/pr-1083.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: Removing Feature.AD_HOC_FORMATTING from FormattingService
+  description: Fixes bug where generated code or automated refactoring is formatted
+    incorrectly by removing AD_HOC_FORMATTING
   links:
   - https://github.com/palantir/palantir-java-format/pull/1083

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -61,7 +61,7 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
 
     @Override
     public @NotNull Set<Feature> getFeatures() {
-        return Set.of(Feature.AD_HOC_FORMATTING, Feature.FORMAT_FRAGMENTS, Feature.OPTIMIZE_IMPORTS);
+        return Set.of(Feature.FORMAT_FRAGMENTS, Feature.OPTIMIZE_IMPORTS);
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
In https://github.com/palantir/palantir-java-format/pull/1078  we switched to the new Formatting APIs following google-java-format's commit: https://github.com/google/google-java-format/commit/84b2c9a2ba382ee7a968518b46afb0d6000ada8d
However, this broke the Intelij generation code - see: 

new generated code after extracting code: 
![wrong](https://github.com/palantir/palantir-java-format/assets/25724655/995b05af-bb06-427e-ab16-4f1d55968d1c)

expected code after extracting code:
![correct](https://github.com/palantir/palantir-java-format/assets/25724655/81ea0a83-103f-4601-9466-2d347f248027)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Removing Feature.AD_HOC_FORMATTING from PalantirJavaFormatFormattingService . The flag was remoced from google-java-format as well in a later PR: https://github.com/google/google-java-format/commit/25ce685ffbc1143f3e7d93c8655e8590cfaaf61b

==COMMIT_MSG==
Remove AD_HOC_FORMATTING
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Fixes https://github.com/palantir/palantir-java-format/issues/1080