### PR TITLE
Fix issue where formatter is not always enabled on save in intellij

### DIFF
--- a/changelog/@unreleased/pr-1110.v2.yml
+++ b/changelog/@unreleased/pr-1110.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The formatter should now always been enabled on save in intellij.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1110

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -49,8 +49,8 @@ class ConfigureJavaFormatterXml {
     }
 
     private static void configureOnSaveAction(Node onSaveOptions) {
-        // If myRunOnSave is set to true, IntelliJ removes it. If it's set to false, we still need it to run.
-        // So we should just remove it so we do run on save.
+        // If myRunOnSave is set to true, IntelliJ removes it. If it's set to false, we still need to remove it to run
+        // the formatter. So we should just remove it so we do run on save.
         matchChild(onSaveOptions, 'option', [name: 'myRunOnSave']).ifPresent { myRunOnSave ->
             onSaveOptions.remove(myRunOnSave)
         }

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -49,19 +49,18 @@ class ConfigureJavaFormatterXml {
     }
 
     private static void configureOnSaveAction(Node onSaveOptions) {
-        def myRunOnSave = matchOrCreateChild(onSaveOptions, 'option', [name: 'myRunOnSave'])
-
-        def myRunOnSaveAlreadySet = Optional.ofNullable(myRunOnSave.attribute('value'))
-                .map(Boolean::parseBoolean)
-                .orElse(false)
-
-        myRunOnSave.attributes().put('value', 'true')
+        // If myRunOnSave is set to true, IntelliJ removes it. If it's set to false, we still need it to run.
+        // So we should just remove it so we do run on save.
+        matchChild(onSaveOptions, 'option', [name: 'myRunOnSave']).ifPresent { myRunOnSave ->
+            onSaveOptions.remove(myRunOnSave)
+        }
 
         def myAllFileTypesSelectedAlreadySet = matchChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected'])
                 .map { Boolean.parseBoolean(it.attribute('value')) }
-                .orElse(true)
+                // If myAllFileTypesSelected is elided then it is disabled by default
+                .orElse(false)
 
-        if (myRunOnSaveAlreadySet && myAllFileTypesSelectedAlreadySet) {
+        if (myAllFileTypesSelectedAlreadySet) {
             // If the user has already configured IntelliJ to format all file types and turned on formatting on save,
             // we leave the configuration as is as it will format java code, and we don't want to disable formatting
             // for other file types

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -55,7 +55,8 @@ class ConfigureJavaFormatterXml {
             onSaveOptions.remove(myRunOnSave)
         }
 
-        def myAllFileTypesSelectedAlreadySet = matchChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected'])
+        def myAllFilesTypesSelected = matchChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected'])
+        def myAllFileTypesSelectedAlreadySet = myAllFilesTypesSelected
                 .map { Boolean.parseBoolean(it.attribute('value')) }
                 // If myAllFileTypesSelected is elided then it is disabled by default
                 .orElse(false)
@@ -67,8 +68,7 @@ class ConfigureJavaFormatterXml {
             return
         }
 
-        // Otherwise we setup intellij to not format all files...
-        matchOrCreateChild(onSaveOptions, 'option', [name: 'myAllFileTypesSelected']).attributes().put('value', 'false')
+        myAllFilesTypesSelected.ifPresent { onSaveOptions.remove(it) }
 
         // ...but ensure java is formatted
         def mySelectedFileTypes = matchOrCreateChild(onSaveOptions, 'option', [name: 'mySelectedFileTypes'])

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -122,8 +122,6 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         then:
         def expected = """
             <component name="${action}OnSaveOptions">
-              <option name="myRunOnSave" value="true"/>
-              <option name="myAllFileTypesSelected" value="false"/>
               <option name="mySelectedFileTypes">
                 <set>
                   <option value="JAVA"/>
@@ -143,8 +141,6 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         def node = new XmlParser().parseText """
             <root>
               <component name="${action}OnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <option name="myAllFileTypesSelected" value="false"/>
                 <option name="mySelectedFileTypes">
                   <set>
                     <option value="Go"/>
@@ -161,8 +157,6 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         then:
         def expected = """
             <component name="${action}OnSaveOptions">
-              <option name="myRunOnSave" value="true"/>
-              <option name="myAllFileTypesSelected" value="false"/>
               <option name="mySelectedFileTypes">
                 <set>
                   <option value="Go"/>
@@ -183,8 +177,7 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         def node = new XmlParser().parseText """
             <root>
               <component name="${action}OnSaveOptions">
-                <option name="myRunOnSave" value="true"/>
-                <!-- if myAllFileTypesSelected does not exist, it defaults to true -->
+                <option name="myAllFileTypesSelected" value="true"/>
               </component>
             </root>
         """.stripIndent(true)
@@ -196,7 +189,7 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         then:
         def expected = """
             <component name="${action}OnSaveOptions">
-              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="true"/>
             </component>
         """.stripIndent(true).strip()
 


### PR DESCRIPTION
## Before this PR
We've had sporadic reports of the formatter not being enabled on save in intellij. I ran into this yesterday and today.

## After this PR
==COMMIT_MSG==
The formatter should now always been enabled on save in intellij.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

