### PR TITLE
Handle actions on save config correctly across IntelliJ versions

### DIFF
--- a/changelog/@unreleased/pr-1112.v2.yml
+++ b/changelog/@unreleased/pr-1112.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure Actions on Save is configured properly in IntelliJ <=2023.3.6
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1112

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -122,6 +122,8 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         then:
         def expected = """
             <component name="${action}OnSaveOptions">
+              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="false"/>
               <option name="mySelectedFileTypes">
                 <set>
                   <option value="JAVA"/>
@@ -163,6 +165,8 @@ class ConfigureJavaFormatterXmlTest extends Specification {
                   <option value="JAVA"/>
                 </set>
               </option>
+              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="false"/>
             </component>
         """.stripIndent(true).strip()
 
@@ -190,6 +194,51 @@ class ConfigureJavaFormatterXmlTest extends Specification {
         def expected = """
             <component name="${action}OnSaveOptions">
               <option name="myAllFileTypesSelected" value="true"/>
+              <option name="myRunOnSave" value="true"/>
+              <option name="mySelectedFileTypes">
+                <set>
+                  <option value="JAVA"/>
+                </set>
+              </option>
+            </component>
+        """.stripIndent(true).strip()
+
+        newXml == expected
+
+        where:
+        action << ACTIONS_ON_SAVE
+    }
+
+    @Unroll
+    def 'if the myRunOnSave for #action on save is explicitly disabled, turn it on'() {
+        def node = new XmlParser().parseText """
+            <root>
+              <component name="${action}OnSaveOptions">
+                <option name="myRunOnSave" value="false"/>
+                <option name="myAllFileTypesSelected" value="false"/>
+                <option name="mySelectedFileTypes">
+                  <set>
+                    <option value="JAVA"/>
+                  </set>
+                </option>
+              </component>
+            </root>
+        """.stripIndent(true)
+
+        when:
+        ConfigureJavaFormatterXml.configureWorkspaceXml(node)
+        def newXml = xmlSubcomponentToString(node, "${action}OnSaveOptions")
+
+        then:
+        def expected = """
+            <component name="${action}OnSaveOptions">
+              <option name="myRunOnSave" value="true"/>
+              <option name="myAllFileTypesSelected" value="false"/>
+              <option name="mySelectedFileTypes">
+                <set>
+                  <option value="JAVA"/>
+                </set>
+              </option>
             </component>
         """.stripIndent(true).strip()
 


### PR DESCRIPTION
## Before this PR
In #1110, I attempted to fix the formatter not being enabled for Actions on Save in 2024.1. However, it appears this broke people using <=2023.3.6, as the defaults for `myRunOnSave` and `myAllFileTypesSelected` had changed between 2023.3.6 and 2023.3.7.

## After this PR
==COMMIT_MSG==
Ensure Actions on Save is configured properly in IntelliJ <=2023.3.6
==COMMIT_MSG==

I tested on IntelliJ 2024.1.4 and 2023.2.7. We now make the config in a way that should not be ambiguous in either IDE version.

## Possible downsides?
This doesn't work with some other version of intellij.

