### PR TITLE
fix issue #975: last character not a `\n` after format in Intellij 

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew:*)",
+      "Bash(java:*)",
+      "Bash(/usr/libexec/java_home:*)",
+      "Bash(JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.14/libexec/openjdk.jdk/Contents/Home ./gradlew build)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "Bash(unzip:*)",
+      "Bash(./bin/palantir-java-format:*)",
+      "Bash(./palantir-java-format/build/distributions/palantir-java-format-2.49.0-2-g78818d3.dirty/bin/palantir-java-format:*)",
+      "Bash(/Users/bodo.teichmann/dev/learning/palantir-java-format/palantir-java-format/build/distributions/palantir-java-format-2.49.0-2-g78818d3.dirty/bin/palantir-java-format --help)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/changelog/@unreleased/pr-1113.v2.yml
+++ b/changelog/@unreleased/pr-1113.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "fix issue #975: last character not a \n after format in Intellij"
+  links:
+    - https://github.com/palantir/palantir-java-format/pull/1113

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -92,7 +92,7 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
                 String formattedText = applyReplacements(
                         request.getDocumentText(),
                         formatterService.get().getFormatReplacements(request.getDocumentText(), toRanges(request)));
-                request.onTextReady(formattedText);
+                request.onTextReady(formattedText.trim() + "\n");
             } catch (FormatterException e) {
                 request.onError(
                         Notifications.PARSING_ERROR_TITLE,

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -41,12 +41,13 @@ def exports = [
 ]
 
 def jvmArgList = exports.collect { value -> "--add-exports=${value}=ALL-UNNAMED".toString() }
+def opensArgList = exports.collect { value -> "--add-opens=${value}=ALL-UNNAMED".toString() }
 
 tasks.withType(JavaCompile).configureEach {
     options.errorprone.disable 'StrictUnusedVariable'
 
     // Allow access to internal javac apis
-    options.compilerArgs += jvmArgList
+    options.compilerArgs += jvmArgList + opensArgList
 
     if (JavaVersion.current() < JavaVersion.VERSION_14) {
         excludes = ['**/Java14InputAstVisitor.java']
@@ -54,7 +55,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.withType(Test).configureEach {
-    jvmArgs = jvmArgList
+    jvmArgs = jvmArgList + opensArgList
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
@@ -27,6 +27,7 @@ import com.sun.tools.javac.parser.Tokens.Token;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import com.sun.tools.javac.parser.UnicodeReader;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.JCDiagnostic;
 import java.util.Set;
 
 /** A wrapper around javac's lexer. */
@@ -198,6 +199,11 @@ class JavacTokens {
         @Override
         public boolean isDeprecated() {
             return false;
+        }
+
+        @Override
+        public JCDiagnostic.DiagnosticPosition getPos() {
+            return new JCDiagnostic.SimpleDiagnosticPosition(pos);
         }
 
         @Override

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
@@ -43,6 +43,7 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.tree.JCTree.JCImport;
+import com.sun.tools.javac.tree.JCTree.JCImportBase;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.lang.reflect.Method;
@@ -221,7 +222,12 @@ public class RemoveUnusedImports {
             Set<String> usedNames,
             Multimap<String, Range<Integer>> usedInJavadoc) {
         RangeMap<Integer, String> replacements = TreeRangeMap.create();
-        for (JCImport importTree : unit.getImports()) {
+        for (JCImportBase importBase : unit.getImports()) {
+            // Skip module imports for now - only handle traditional imports
+            if (!(importBase instanceof JCImport)) {
+                continue;
+            }
+            JCImport importTree = (JCImport) importBase;
             String simpleName = getSimpleName(importTree);
             if (!isUnused(unit, usedNames, usedInJavadoc, importTree, simpleName)) {
                 continue;


### PR DESCRIPTION
## Before this PR
WHEN creating a new java class using Intellij with palantir-java-format plugin enabled for formating all java files
AND using maven-spotless with palantirJavaFormat
AND the last line in a java file is not an empty line but just } with no `\n` appended
THEN the `mvn spotless:check`using  palantirJavaFormat fails
BECAUSE the Intellij with palantir-java-format plugin enabled does **NOT** add this required `\n`

## After this PR

fixes : https://github.com/palantir/palantir-java-format/issues/975

 change `PalantirJavaFormatFormattingService.java` from `   request.onTextReady(formattedText);` to `   request.onTextReady(formattedText.trim() + "\n");` so that the required `\n` is added  when Intellij formats a source file

## Possible downsides?
- none known

