### PR TITLE
Use com.palantir.external-publish-intellij for idea plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ buildscript {
     }
 }
 
+plugins {
+    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
+}
+
+
 apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.git-version'

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,6 @@ buildscript {
     }
 }
 
-plugins {
-    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
-}
-
-
 apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.git-version'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.gradle.publish:plugin-publish-plugin:1.2.2'
         classpath 'com.palantir.baseline:gradle-baseline-java:5.65.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.23.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.17.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.18.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.12.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.1.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.40.0'
@@ -17,11 +17,6 @@ buildscript {
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.40.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
     }
-}
-
-plugins {
-    id "org.jetbrains.intellij" version "1.17.3" apply false
-    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
 }
 
 apply plugin: 'com.palantir.external-publish'

--- a/changelog/@unreleased/pr-1127.v2.yml
+++ b/changelog/@unreleased/pr-1127.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use com.palantir.external-publish-intellij for idea plugins
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1127

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven-publish'
-apply plugin: 'org.jetbrains.intellij'
-
-apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'com.palantir.external-publish-intellij'
 
 def name = "palantir-java-format"
 intellij {
@@ -27,29 +24,10 @@ intellij {
     plugins = ['java']
 }
 
-def buildPlugin = tasks.named("buildPlugin")
-
-tasks.named("runIde") {
-    // Allow debugging
-    jvmArgs '--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED'
-
-    dependsOn(buildPlugin)
-}
-
 patchPluginXml {
     pluginDescription = "Formats source code using the palantir-java-format tool."
-    version = project.version
     sinceBuild = '213' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
-}
-
-def publishPlugin = tasks.named("publishPlugin") {
-    onlyIf { versionDetails().isCleanTag }
-
-    token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
-}
-tasks.named("publish") {
-    dependsOn(publishPlugin)
 }
 
 configurations {
@@ -58,6 +36,20 @@ configurations {
 
         canBeConsumed = false
         canBeResolved = true
+    }
+}
+
+// This task will resolve runtimeClasspath without telling Gradle that it depends on it, therefore dependent jars won't
+// be created beforehand. Therefore, ensure that it knows about it.
+// see https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/groovy/org/jetbrains/intellij/tasks/PrepareSandboxTask.groovy
+tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask).configureEach {
+    dependsOn configurations.runtimeClasspath
+
+    // Also pack the formatter in its own directory
+    into("${name}/impl") {
+        // Note that we don't filter down the jars in the impl directory due to behavior when
+        // the formatter is bootstrapped with jdk16+ exports.
+        from configurations.formatter
     }
 }
 
@@ -82,43 +74,6 @@ tasks.withType(JavaCompile).configureEach {
     options.errorprone.disable 'PreferSafeLogger'
     options.errorprone.disable 'PreferSafeLoggableExceptions'
     options.errorprone.disable 'PreferSafeLoggingPreconditions'
-}
-
-tasks.named("check") {
-    dependsOn(buildPlugin, tasks.named("verifyPlugin"))
-}
-// This task will resolve runtimeClasspath without telling Gradle that it depends on it, therefore dependent jars won't
-// be created beforehand. Therefore, ensure that it knows about it.
-// see https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/groovy/org/jetbrains/intellij/tasks/PrepareSandboxTask.groovy
-tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask).configureEach {
-    dependsOn configurations.runtimeClasspath
-
-    // Also pack the formatter in its own directory
-    into("${name}/impl") {
-        // Note that we don't filter down the jars in the impl directory due to behavior when
-        // the formatter is bootstrapped with jdk16+ exports.
-        from configurations.formatter
-    }
-}
-
-tasks.named("buildSearchableOptions") {
-    enabled = false
-}
-
-// Prevent nebula.maven-publish from trying to publish components.java - we are publishing our own different artifact
-ext."nebulaPublish.maven.jar" = false
-
-publishing {
-    publications {
-        nebula(MavenPublication) {
-            artifact buildPlugin
-        }
-    }
-}
-
-versionsLock {
-    // 'org.jetbrains.intellij' creates a dependency on *IntelliJ*, which GCV cannot resolve
-    disableJavaPluginDefaults()
 }
 
 // Javadoc fails if there are no public classes to javadoc, so make it stop complaining.


### PR DESCRIPTION
## Before this PR
Had the same copy and pasted block of code for publishing intellij plugins which was not centrally managed

## After this PR
Migrated to the `com.palantir.external-publish-intellij` plugin to handle the publication of intellij plugins