### PR TITLE
Update native image build flags: add `--exact-reachability-metadata`

### DIFF
--- a/changelog/@unreleased/pr-1212.v2.yml
+++ b/changelog/@unreleased/pr-1212.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Update native image build flags: add `--exact-reachability-metadata`'
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1212

--- a/palantir-java-format-native/build.gradle
+++ b/palantir-java-format-native/build.gradle
@@ -62,6 +62,7 @@ graalvmNative {
                     '--initialize-at-build-time=com.sun.tools.javac.file.Locations',
                     '-H:+ReportExceptionStackTraces',
                     '-H:-UseContainerSupport',
+                    '--exact-reachability-metadata',
                     "-march=compatibility")
             jvmArgs.addAll(jvmArgList)
         }


### PR DESCRIPTION
## Before this PR
The Graal build flag `--exact-reachability-metadata` is not set.

## After this PR
Set the  `--exact-reachability-metadata` flag. The flag was added to address [this issue](https://github.com/oracle/graal/issues/5171). [This will be the default mode of operation in future versions of Graal](https://www.graalvm.org/latest/reference-manual/native-image/metadata/#:~:text=The%20user%2Dfriendly%20implementation%20for%20reflection%20will%20become%20the%20default%20in%20future%20releases%20of%20GraalVM%20so%20the%20timely%20adoption%20is%20important%20to%20avoid%20project%20breakage.). Setting the flag now will allow us to proactively catch any issues before updating to a new Graal version where this behavior is the default.

==COMMIT_MSG==
Update native image build flags: add `--exact-reachability-metadata`
==COMMIT_MSG==

## Possible downsides?
This will fail loudly at runtime when there are failures. There are other options - running the native image with `-XX:MissingRegistrationReportingMode=Warn` will drop warning logs at application startup when there are missing registrations. We're early enough in using the native images that we can afford to have a potentially breaking change.