### PR TITLE
Fix path in Eclipse plugin installation instructions

### DIFF
--- a/eclipse_plugin/README.md
+++ b/eclipse_plugin/README.md
@@ -16,5 +16,5 @@
    --add-exports
    jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
    ```
-1. Copy `build/libs/palantir-java-format-eclipse-plugin-<version>.jar` to the `dropins` folder of your Eclipse installation,
+1. Copy `eclipse_plugin/build/libs/palantir-java-format-eclipse-plugin-<version>.jar` to the `dropins` folder of your Eclipse installation,
 1. Run `eclipse -clean`.


### PR DESCRIPTION
## Before this PR
In the Eclipse plugin installation instructions, the path of the generated jar file is wrong.

## After this PR
In the Eclipse plugin installation instructions, the path of the generated jar file is correct.

## Possible downsides?
None.

