### PR TITLE
Make palantir-java-format dynamically unloadable

### DIFF
--- a/changelog/@unreleased/pr-1232.v2.yml
+++ b/changelog/@unreleased/pr-1232.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Make palantir-java-format dynamically unloadable
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1232

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,8 @@
             implementation="com.palantir.javaformat.intellij.PalantirJavaFormatFormattingService"/>
     <projectConfigurable instance="com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable"
                          id="palantir-java-format.settings"
-                         displayName="palantir-java-format Settings"/>
+                         displayName="palantir-java-format Settings"
+                         nonDefaultProject="true"/>
     <projectService serviceImplementation="com.palantir.javaformat.intellij.PalantirJavaFormatSettings"/>
     <postStartupActivity implementation="com.palantir.javaformat.intellij.InitialConfigurationStartupActivity"/>
     <notificationGroup displayType="BALLOON" id="palantir-java-format parsing error"

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin url="https://github.com/palantir/palantir-java-format">
+<idea-plugin url="https://github.com/palantir/palantir-java-format" require-restart="false">
   <id>palantir-java-format</id>
   <name>palantir-java-format</name>
   <vendor url="https://github.com/palantir/palantir-java-format">


### PR DESCRIPTION
## Before this PR
If it was unloaded before a project was opened a memory leak occurred due to the settings page being created for the default project

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Now we ensure that the settings page is not set for the default project allowing dynamic unload
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

