### PR TITLE
Sets min-version for pjf Intellij plugin

### DIFF
--- a/changelog/@unreleased/pr-1237.v2.yml
+++ b/changelog/@unreleased/pr-1237.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Sets min-version for pjf Intellij plugin
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1237

--- a/changelog/@unreleased/pr-1237.v2.yml
+++ b/changelog/@unreleased/pr-1237.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
+type: improvement
+improvement:
   description: Sets min-version for pjf Intellij plugin
   links:
   - https://github.com/palantir/palantir-java-format/pull/1237

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -39,7 +39,7 @@ class ConfigureJavaFormatterXml {
 
     static void configureExternalDependencies(Node rootNode, String minVersion) {
         def externalDependencies = matchOrCreateChild(rootNode, 'component', [name: 'ExternalDependencies'])
-        matchOrCreateChild(externalDependencies, 'plugin', [id: 'palantir-java-format'], ['min-version' : minVersion])
+        matchOrCreateChild(externalDependencies, 'plugin', [id: 'palantir-java-format'], [:], ['min-version' : minVersion])
     }
 
     static void configureWorkspaceXml(Node rootNode) {
@@ -76,15 +76,15 @@ class ConfigureJavaFormatterXml {
         matchOrCreateChild(set, 'option', [value: 'JAVA'])
     }
 
-    private static Node matchOrCreateChild(Node base, String name, Map keyAttributes = [:], Map otherAttributes = [:]) {
-        Node node = base[name].find { it.attributes().entrySet().containsAll(keyAttributes.entrySet()) } as Node
-        if (Optional.ofNullable(node).isEmpty()) {
-            return base.appendNode(name, keyAttributes + otherAttributes)
-        } else {
-            node.attributes().clear()
-            node.attributes().putAll(keyAttributes + otherAttributes)
+
+    private static Node matchOrCreateChild(Node base, String name, Map attributes = [:], Map defaults = [:], Map overrides = [:]) {
+        matchChild(base, name, attributes).map {it -> {
+            it.attributes().putAll(overrides)
+            return it
+        } }.orElseGet {
+            base.appendNode(name, attributes + defaults + overrides)
         }
-        return node
+
     }
 
     private static Optional<Node> matchChild(Node base, String name, Map attributes = [:]) {

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXml.groovy
@@ -37,9 +37,9 @@ class ConfigureJavaFormatterXml {
         })
     }
 
-    static void configureExternalDependencies(Node rootNode) {
+    static void configureExternalDependencies(Node rootNode, String minVersion) {
         def externalDependencies = matchOrCreateChild(rootNode, 'component', [name: 'ExternalDependencies'])
-        matchOrCreateChild(externalDependencies, 'plugin', [id: 'palantir-java-format'])
+        matchOrCreateChild(externalDependencies, 'plugin', [id: 'palantir-java-format'], ['min-version' : minVersion])
     }
 
     static void configureWorkspaceXml(Node rootNode) {
@@ -76,10 +76,15 @@ class ConfigureJavaFormatterXml {
         matchOrCreateChild(set, 'option', [value: 'JAVA'])
     }
 
-    private static Node matchOrCreateChild(Node base, String name, Map attributes = [:], Map defaults = [:]) {
-        matchChild(base, name, attributes).orElseGet {
-            base.appendNode(name, attributes + defaults)
+    private static Node matchOrCreateChild(Node base, String name, Map keyAttributes = [:], Map otherAttributes = [:]) {
+        Node node = base[name].find { it.attributes().entrySet().containsAll(keyAttributes.entrySet()) } as Node
+        if (Optional.ofNullable(node).isEmpty()) {
+            return base.appendNode(name, keyAttributes + otherAttributes)
+        } else {
+            node.attributes().clear()
+            node.attributes().putAll(keyAttributes + otherAttributes)
         }
+        return node
     }
 
     private static Optional<Node> matchChild(Node base, String name, Map attributes = [:]) {

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -41,6 +41,8 @@ import org.xml.sax.SAXException;
 
 public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
 
+    private static final String MIN_IDEA_PLUGIN_VERSION = "2.57.0";
+
     @Override
     public void apply(Project rootProject) {
         Preconditions.checkState(
@@ -77,7 +79,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
             Optional<URI> nativeUri =
                     nativeImplConfiguration.map(conf -> conf.getSingleFile().toURI());
             ConfigureJavaFormatterXml.configureJavaFormat(xmlProvider.asNode(), uris, nativeUri);
-            ConfigureJavaFormatterXml.configureExternalDependencies(xmlProvider.asNode());
+            ConfigureJavaFormatterXml.configureExternalDependencies(xmlProvider.asNode(), MIN_IDEA_PLUGIN_VERSION);
         });
 
         ideaModel.getWorkspace().getIws().withXml(xmlProvider -> {
@@ -106,18 +108,17 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
                     node -> ConfigureJavaFormatterXml.configureJavaFormat(node, uris, nativeImageUri));
             createOrUpdateIdeaXmlFile(
                     project.file(".idea/externalDependencies.xml"),
-                    node -> ConfigureJavaFormatterXml.configureExternalDependencies(node));
+                    node -> ConfigureJavaFormatterXml.configureExternalDependencies(node, MIN_IDEA_PLUGIN_VERSION));
             createOrUpdateIdeaXmlFile(
-                    project.file(".idea/workspace.xml"), node -> ConfigureJavaFormatterXml.configureWorkspaceXml(node));
+                    project.file(".idea/workspace.xml"), ConfigureJavaFormatterXml::configureWorkspaceXml);
 
             // Still configure legacy idea if using intellij import
             updateIdeaXmlFileIfExists(project.file(project.getName() + ".ipr"), node -> {
                 ConfigureJavaFormatterXml.configureJavaFormat(node, uris, nativeImageUri);
-                ConfigureJavaFormatterXml.configureExternalDependencies(node);
+                ConfigureJavaFormatterXml.configureExternalDependencies(node, MIN_IDEA_PLUGIN_VERSION);
             });
-            updateIdeaXmlFileIfExists(project.file(project.getName() + ".iws"), node -> {
-                ConfigureJavaFormatterXml.configureWorkspaceXml(node);
-            });
+            updateIdeaXmlFileIfExists(
+                    project.file(project.getName() + ".iws"), ConfigureJavaFormatterXml::configureWorkspaceXml);
         });
     }
 

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/ConfigureJavaFormatterXmlTest.groovy
@@ -21,6 +21,42 @@ import spock.lang.Unroll
 
 class ConfigureJavaFormatterXmlTest extends Specification {
 
+    private static final String EXTERNAL_DEPENDENCIES_NO_PJF = """\
+            <project version="4">
+              <component name="ExternalDependencies">
+                <plugin id="CheckStyle-IDEA"/>
+              </component>
+            </project>
+        """.stripIndent(true)
+
+    private static final String EXTERNAL_DEPENDENCIES_WITH_PJF = """\
+            <project version="4">
+              <component name="ExternalDependencies">
+                <plugin id="CheckStyle-IDEA"/>
+                <plugin id="palantir-java-format"/>
+              </component>
+            </project>
+        """.stripIndent(true)
+
+    private static final String EXTERNAL_DEPENDENCIES_WITH_PINNED_PJF = """\
+            <project version="4">
+              <component name="ExternalDependencies">
+                <plugin id="CheckStyle-IDEA"/>
+                <plugin id="palantir-java-format" min-version="1.0.0"/>
+              </component>
+            </project>
+        """.stripIndent(true)
+
+
+    private static final String EXPECTED_EXTERNAL_DEPENDENCIES = """\
+            <project version="4">
+              <component name="ExternalDependencies">
+                <plugin id="CheckStyle-IDEA"/>
+                <plugin id="palantir-java-format" min-version="9.9.9"/>
+              </component>
+            </project>
+        """.stripIndent(true)
+
     private static final String EXISTING_CLASS_PATH = """
             <root>
                 <component name="PalantirJavaFormatSettings">
@@ -274,6 +310,20 @@ class ConfigureJavaFormatterXmlTest extends Specification {
 
         where:
         action << ACTIONS_ON_SAVE
+    }
+
+    @Unroll
+    def 'can update externalDependencies file'(input) {
+        def node = new XmlParser().parseText(input)
+
+        when:
+        ConfigureJavaFormatterXml.configureExternalDependencies(node, "9.9.9")
+
+        then:
+        xmlToString(node) == EXPECTED_EXTERNAL_DEPENDENCIES
+
+        where:
+        input << [EXTERNAL_DEPENDENCIES_NO_PJF, EXTERNAL_DEPENDENCIES_WITH_PINNED_PJF, EXTERNAL_DEPENDENCIES_WITH_PJF]
     }
 
     private static String xmlSubcomponentToString(Node node, String name) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Sets the min-version of the pjf Intellij plugin. Intellij will show a pop-up when the installed Intellij plugin is lower than the minimum required version.
![Screenshot 2025-03-13 at 3 07 43 PM](https://github.com/user-attachments/assets/2a604be5-1b24-4817-81de-4b023e766842)
FLUP for https://pl.ntr/2rX - to prompt people to update the Intellij plugin until we have the [plugin updater released everywhere](https://github.com/palantir/palantir-idea-plugin-updater).

==COMMIT_MSG==
Sets min-version for pjf Intellij plugin
==COMMIT_MSG==



## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

