### PR TITLE
SpotlessApply uses by default the Java formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ shortcut.
 
 ![Install plugin from disk](./docs/images/install_plugin_from_disk.png)
 
+## Java 21 Support
+
+In [1211](https://github.com/palantir/palantir-java-format/pull/1211) we shipped Java 21 support. In order to use the 
+Java 21 formatting capabilities, ensure that either: 
+
+- the Gradle daemon and the Intellij Project SDK are set to Java 21
+- or that the gradle property `palantir.native.formatter=true`. This will run the formatter as a native image, 
+- independent of the Gradle daemon/Intellij project JDK version. 
+
+### Native image formatter
+
+[This comment](https://github.com/palantir/palantir-java-format/issues/952#issuecomment-2575750610) explains why we 
+switched to a native image for the formatter. The startup time for the native image esp. in Intellij is >10x faster than
+spinning up a new process that does the formatting.
+However, the throughput of running the native image for a large set of files (eg. running `./gradlew spotlessApply`) is 
+considerably slower (eg. 30ms using the Java implementation vs 1m20s using the native image implementation). Therefore,
+when running the formatter from `spotlessApply` we will default to using the Java implementation (if the Java version >= 21).
+
+
 ## Future works
 
 - [ ] preserve [NON-NLS markers][] - these are comments that are used when implementing NLS internationalisation, and need to stay on the same line with the strings they come after.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Java 21 formatting capabilities, ensure that either:
 
 [This comment](https://github.com/palantir/palantir-java-format/issues/952#issuecomment-2575750610) explains why we 
 switched to a native image for the formatter. The startup time for the native image esp. in Intellij is >10x faster than
-spinning up a new process that does the formatting.
+spinning up a new JVM process that does the formatting.
 However, the throughput of running the native image for a large set of files (eg. running `./gradlew spotlessApply`) is 
 considerably slower (eg. 30s using the Java implementation vs 1m20s using the native image implementation). Therefore,
 when running the formatter from `spotlessApply` we will default to using the Java implementation (if the Java version >= 21).

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Java 21 formatting capabilities, ensure that either:
 switched to a native image for the formatter. The startup time for the native image esp. in Intellij is >10x faster than
 spinning up a new process that does the formatting.
 However, the throughput of running the native image for a large set of files (eg. running `./gradlew spotlessApply`) is 
-considerably slower (eg. 30ms using the Java implementation vs 1m20s using the native image implementation). Therefore,
+considerably slower (eg. 30s using the Java implementation vs 1m20s using the native image implementation). Therefore,
 when running the formatter from `spotlessApply` we will default to using the Java implementation (if the Java version >= 21).
 
 

--- a/changelog/@unreleased/pr-1243.v2.yml
+++ b/changelog/@unreleased/pr-1243.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: SpotlessApply uses Java 21 version
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1243

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -60,7 +60,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
     }
 
     private static Optional<Configuration> maybeGetNativeImplConfiguration(Project rootProject) {
-        return NativeImageFormatProviderPlugin.shouldUseNativeImage(rootProject)
+        return NativeImageFormatProviderPlugin.canUseNativeImage(rootProject)
                 ? Optional.of(rootProject
                         .getConfigurations()
                         .getByName(NativeImageFormatProviderPlugin.NATIVE_CONFIGURATION_NAME))

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -60,7 +60,7 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
     }
 
     private static Optional<Configuration> maybeGetNativeImplConfiguration(Project rootProject) {
-        return NativeImageFormatProviderPlugin.canUseNativeImage(rootProject)
+        return NativeImageFormatProviderPlugin.isNativeImageConfigured(rootProject)
                 ? Optional.of(rootProject
                         .getConfigurations()
                         .getByName(NativeImageFormatProviderPlugin.NATIVE_CONFIGURATION_NAME))

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
@@ -76,13 +76,13 @@ public final class PalantirJavaFormatPlugin implements Plugin<Project> {
         @TaskAction
         public final void formatDiff() throws IOException, InterruptedException {
             if (getNativeImage().isPresent()) {
-                log.info("Using the native-image to format");
+                log.info("Using the native-image formatter");
                 FormatDiff.formatDiff(
                         getProject().getProjectDir().toPath(),
                         new NativeImageFormatterService(
                                 getNativeImage().get().getAsFile().toPath()));
             } else {
-                log.info("Using legacy java formatter");
+                log.info("Using the Java-based formatter");
                 JavaFormatExtension extension =
                         getProject().getRootProject().getExtensions().getByType(JavaFormatExtension.class);
                 FormatterService formatterService = extension.serviceLoad();

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
@@ -46,7 +46,7 @@ public final class PalantirJavaFormatPlugin implements Plugin<Project> {
             // TODO(dfox): in the future we may want to offer a simple 'format' task so people don't need to use
             // spotless to try out our formatter
             project.getTasks().register("formatDiff", FormatDiffTask.class, task -> {
-                if (NativeImageFormatProviderPlugin.shouldUseNativeImage(project)) {
+                if (NativeImageFormatProviderPlugin.canUseNativeImage(project)) {
                     task.getNativeImage().fileProvider(getNativeImplConfiguration(project));
                 }
             });

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
@@ -46,7 +46,7 @@ public final class PalantirJavaFormatPlugin implements Plugin<Project> {
             // TODO(dfox): in the future we may want to offer a simple 'format' task so people don't need to use
             // spotless to try out our formatter
             project.getTasks().register("formatDiff", FormatDiffTask.class, task -> {
-                if (NativeImageFormatProviderPlugin.canUseNativeImage(project)) {
+                if (NativeImageFormatProviderPlugin.isNativeImageConfigured(project)) {
                     task.getNativeImage().fileProvider(getNativeImplConfiguration(project));
                 }
             });

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.palantir.platform.Architecture;
 import com.palantir.platform.OperatingSystem;
 import java.util.Optional;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
@@ -38,7 +37,7 @@ public final class NativeImageFormatProviderPlugin implements Plugin<Project> {
                 rootProject == rootProject.getRootProject(),
                 "May only apply com.palantir.java-format-provider to the root project");
 
-        if (!canUseNativeImage(rootProject)) {
+        if (!isNativeImageConfigured(rootProject)) {
             log.info("Skipping native image configuration as it is not supported on this platform");
             return;
         }
@@ -69,13 +68,7 @@ public final class NativeImageFormatProviderPlugin implements Plugin<Project> {
         });
     }
 
-    // Used only by the spotlessApply workflow; native images have a lower throughput than Java-based implementations,
-    // when running the formatter on a large amount of
-    public static boolean shouldUseNativeImage(Project project) {
-        return canUseNativeImage(project) && JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0;
-    }
-
-    public static boolean canUseNativeImage(Project project) {
+    public static boolean isNativeImageConfigured(Project project) {
         return isNativeImageSupported() && isNativeFlagEnabled(project);
     }
 

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.palantir.platform.Architecture;
 import com.palantir.platform.OperatingSystem;
 import java.util.Optional;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
@@ -37,7 +38,7 @@ public final class NativeImageFormatProviderPlugin implements Plugin<Project> {
                 rootProject == rootProject.getRootProject(),
                 "May only apply com.palantir.java-format-provider to the root project");
 
-        if (!shouldUseNativeImage(rootProject)) {
+        if (!canUseNativeImage(rootProject)) {
             log.info("Skipping native image configuration as it is not supported on this platform");
             return;
         }
@@ -68,7 +69,13 @@ public final class NativeImageFormatProviderPlugin implements Plugin<Project> {
         });
     }
 
+    // Used only by the Gradle workflow; native images have a lower throughput than Java-based implementations,
+    // when running the formatter on a large amount of
     public static boolean shouldUseNativeImage(Project project) {
+        return canUseNativeImage(project) && JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0;
+    }
+
+    public static boolean canUseNativeImage(Project project) {
         return isNativeImageSupported() && isNativeFlagEnabled(project);
     }
 

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/NativeImageFormatProviderPlugin.java
@@ -69,7 +69,7 @@ public final class NativeImageFormatProviderPlugin implements Plugin<Project> {
         });
     }
 
-    // Used only by the Gradle workflow; native images have a lower throughput than Java-based implementations,
+    // Used only by the spotlessApply workflow; native images have a lower throughput than Java-based implementations,
     // when running the formatter on a large amount of
     public static boolean shouldUseNativeImage(Project project) {
         return canUseNativeImage(project) && JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0;

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -19,6 +19,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.spotless.FormatterStep;
 import com.palantir.javaformat.gradle.spotless.NativePalantirJavaFormatStep;
 import com.palantir.javaformat.gradle.spotless.PalantirJavaFormatStep;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -39,12 +40,12 @@ final class SpotlessInterop {
 
     static FormatterStep addSpotlessJavaFormatStep(Project project) {
         if (NativeImageFormatProviderPlugin.shouldUseNativeImage(project)) {
-            logger.info("Using the native-image palantir-java-formatter");
+            logger.info("Using the native-image formatter");
             return NativePalantirJavaFormatStep.create(project.getRootProject()
                     .getConfigurations()
                     .getByName(NativeImageFormatProviderPlugin.NATIVE_CONFIGURATION_NAME));
         }
-        logger.info("Using the legacy palantir-java-formatter");
+        logger.info("Using the Java-based formatter {}", JavaVersion.current());
         return PalantirJavaFormatStep.create(
                 project.getRootProject()
                         .getConfigurations()

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -39,7 +39,13 @@ final class SpotlessInterop {
     }
 
     static FormatterStep addSpotlessJavaFormatStep(Project project) {
-        if (NativeImageFormatProviderPlugin.shouldUseNativeImage(project)) {
+
+        if (NativeImageFormatProviderPlugin.isNativeImageConfigured(project)
+                // Native images have lower throughput than Java implementations. This logic gets called by the
+                // Gradle spotlessApply step, which formats a full project.
+                // If we are already running on java 21, then we can run the spotlessApply logic using the Java
+                // formatter. Otherwise, we need to run the native-image.
+                && JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0) {
             logger.info("Using the native-image formatter");
             return NativePalantirJavaFormatStep.create(project.getRootProject()
                     .getConfigurations()

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPluginTest.groovy
@@ -93,8 +93,9 @@ class PalantirJavaFormatPluginTest extends IntegrationTestKitSpec {
         '''.stripIndent()
 
         where:
-        extraGradleProperties    | expectedOutput
-        ""                          | "Using legacy java formatter"
-        "palantir.native.formatter=true"  | "Using the native-image to format"
+        // When running on Java 21, gradle will always use the Java formatter
+        extraGradleProperties | expectedOutput
+        "" | "Using the Java-based formatter"
+        "palantir.native.formatter=true" |  "Using the Java-based formatter"
     }
 }

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPluginTest.groovy
@@ -93,9 +93,8 @@ class PalantirJavaFormatPluginTest extends IntegrationTestKitSpec {
         '''.stripIndent()
 
         where:
-        // When running on Java 21, gradle will always use the Java formatter
         extraGradleProperties | expectedOutput
         "" | "Using the Java-based formatter"
-        "palantir.native.formatter=true" |  "Using the Java-based formatter"
+        "palantir.native.formatter=true" |  "Using the native-image formatter"
     }
 }

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -18,6 +18,11 @@ package com.palantir.javaformat.gradle
 import nebula.test.IntegrationTestKitSpec
 import spock.lang.Unroll
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
 class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     /** ./gradlew writeImplClasspath generates this file. */
     private static final CLASSPATH_FILE = new File("build/impl.classpath").absolutePath
@@ -26,20 +31,61 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
 
 
     @Unroll
-    def "formats with spotless when spotless is applied"(String extraGradleProperties, String expectedOutput) {
+    def "formats with spotless when spotless is applied"(String extraGradleProperties, String javaVersion, String expectedOutput) {
         def extraDependencies = extraGradleProperties.isEmpty() ? "" : NATIVE_CONFIG
+        settingsFile << """
+             buildscript {
+                repositories {
+                    mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                    gradlePluginPortal() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                }
+                 dependencies {
+                     classpath 'com.palantir.gradle.jdks:gradle-jdks-settings:0.62.0'
+                 }
+             }
+            apply plugin: 'com.palantir.jdks.settings'
+        """.stripIndent(true)
+
         buildFile << """
+             buildscript {
+                repositories {
+                    mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                    gradlePluginPortal() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                }
+                 dependencies {
+                     classpath 'com.palantir.baseline:gradle-baseline-java:6.21.0'
+                     classpath 'com.palantir.gradle.jdks:gradle-jdks:0.62.0'
+                     classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.17.0'
+                     classpath files(FILES)
+                 }
+             }
+
             // The 'com.diffplug.spotless:spotless-plugin-gradle' dependency is already added by palantir-java-format
             plugins {
                 id 'java'
-                id 'com.palantir.java-format'
             }
+
+            apply plugin: 'com.palantir.java-format'     
+            apply plugin: 'com.palantir.baseline-java-versions'
+            apply plugin: 'com.palantir.jdks'
+            apply plugin: 'com.palantir.jdks.latest'
             
             dependencies {
                 palantirJavaFormat files(file("${CLASSPATH_FILE}").text.split(':'))
                 EXTRA_CONFIGURATION
             }
-        """.replace("EXTRA_CONFIGURATION", extraDependencies).stripIndent()
+            
+            javaVersions {
+                libraryTarget = JAVA_VERSION
+            }
+            
+            jdks {
+                daemonTarget = JAVA_VERSION
+            }
+            
+        """.replace("FILES", getBuildPluginClasspathInjector().join(","))
+                .replace("JAVA_VERSION", javaVersion)
+                .replace("EXTRA_CONFIGURATION", extraDependencies).stripIndent()
 
         // Add jvm args to allow spotless and formatter gradle plugins to run with Java 16+
         file('gradle.properties') << """
@@ -48,6 +94,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
           --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        palantir.jdk.setup.enabled=true
         """.stripIndent()
         file('gradle.properties') << extraGradleProperties
 
@@ -56,19 +103,58 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         """.stripIndent()
 
         file('src/main/java/Main.java').text = invalidJavaFile
+        runTasks('wrapper')
 
         when:
-        def result = runTasks('spotlessApply', '--info')
+        def result = runGradlewTasks('spotlessApply', '--info')
 
         then:
-        result.output.contains(expectedOutput)
+        result.contains(expectedOutput)
         file('src/main/java/Main.java').text == validJavaFile
 
         where:
-        extraGradleProperties   | expectedOutput
-        "" | "Using the legacy palantir-java-formatter"
-        "palantir.native.formatter=true"  | "Using the native-image"
+        extraGradleProperties               | javaVersion   | expectedOutput
+        ""                                  | 21            | "Using the Java-based formatter"
+        "palantir.native.formatter=true"    | 21            | "Using the Java-based formatter"
+        "palantir.native.formatter=true"    | 17            | "Using the native-image formatter"
 
+    }
+
+    private static Iterable<File> getBuildPluginClasspathInjector() {
+        return getPluginClasspathInjector(Path.of("../gradle-palantir-java-format/build/pluginUnderTestMetadata/plugin-under-test-metadata.properties"))
+    }
+
+    private static Iterable<File> getPluginClasspathInjector(Path path) {
+        File propertiesFile = path.toFile()
+        Properties properties = new Properties()
+        propertiesFile.withInputStream { inputStream ->
+            properties.load(inputStream)
+        }
+        String classpath = properties.getProperty('implementation-classpath')
+        return classpath.split(File.pathSeparator).collect { "'" + it + "'" }
+    }
+
+    private String runGradlewTasks(String... tasks) {
+        ProcessBuilder processBuilder = getProcessBuilder(tasks)
+        Process process = processBuilder.start()
+        String output = readAllInput(process.getInputStream())
+        return output
+    }
+
+    public static String readAllInput(InputStream inputStream) {
+        try (Stream<String> lines =
+                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()) {
+            return lines.collect(Collectors.joining("\n"));
+        }
+    }
+
+    private ProcessBuilder getProcessBuilder(String... tasks) {
+        List<String> arguments = ["./gradlew"]
+        Arrays.asList(tasks).forEach(arguments::add)
+        ProcessBuilder processBuilder = new ProcessBuilder()
+                .command(arguments)
+                .directory(projectDir).redirectErrorStream(true)
+        return processBuilder
     }
 
     def validJavaFile = '''\

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -132,19 +132,12 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         return classpath.split(File.pathSeparator).collect { new File(it) }
     }
 
-    private GradlewExecutionResult runGradlewTasksAndFail(String... tasks) {
-        ProcessBuilder processBuilder = getProcessBuilder(tasks)
-        Process process = processBuilder.start()
-        process.waitFor()
-        GradlewExecutionResult result = new GradlewExecutionResult(process)
-        assert result.failure
-    }
-
     private GradlewExecutionResult runGradlewTasks(String... tasks) {
         ProcessBuilder processBuilder = getProcessBuilder(tasks)
         Process process = processBuilder.start()
         process.waitFor()
-        GradlewExecutionResult result = new GradlewExecutionResult(process)
+        String output = readAllInput(process.getInputStream())
+        GradlewExecutionResult result = new GradlewExecutionResult(process.exitValue(), output)
         assert result.success
         return result
     }
@@ -155,10 +148,10 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         private final String standardOutput
         private final Throwable failure
 
-        GradlewExecutionResult(Process process) {
-            this.success = process.exitValue() == 0
-            this.standardOutput =  readAllInput(process.getInputStream())
-            this.failure = process.exitValue() != 0 ? new RuntimeException(String.format("Build failed with exitCode %s", process.exitValue())) : null
+        GradlewExecutionResult(int exitValue, String output) {
+            this.success = exitValue == 0
+            this.standardOutput =  output
+            this.failure = exitValue != 0 ? new RuntimeException(String.format("Build failed with exitCode %s", exitValue)) : null
         }
     }
 

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -135,7 +135,6 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     private GradlewExecutionResult runGradlewTasks(String... tasks) {
         ProcessBuilder processBuilder = getProcessBuilder(tasks)
         Process process = processBuilder.start()
-        process.waitFor()
         String output = readAllInput(process.getInputStream())
         GradlewExecutionResult result = new GradlewExecutionResult(process.exitValue(), output)
         assert result.success

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -16,12 +16,7 @@
 package com.palantir.javaformat.gradle
 
 import nebula.test.IntegrationTestKitSpec
-import nebula.test.functional.ExecutionResult
-import nebula.test.functional.GradleRunner
-import nebula.test.functional.internal.DefaultExecutionResult
-import nebula.test.functional.internal.ExecutedTask
 import nebula.test.functional.internal.classpath.ClasspathAddingInitScriptBuilder
-import org.gradle.api.GradleException
 import spock.lang.Unroll
 
 import java.nio.charset.StandardCharsets
@@ -34,14 +29,9 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     private static final CLASSPATH_FILE = new File("build/impl.classpath").absolutePath
     private static final NATIVE_IMAGE_FILE = new File("build/nativeImage.path")
     private static final NATIVE_CONFIG = String.format("palantirJavaFormatNative files(\"%s\")", NATIVE_IMAGE_FILE.text)
-    private static final String INIT_FILE_NAME = "init.gradle";
-
 
     @Unroll
     def "formats with spotless when spotless is applied"(String extraGradleProperties, String javaVersion, String expectedOutput) {
-        File initScript = new File(projectDir, INIT_FILE_NAME)
-        ClasspathAddingInitScriptBuilder.build(initScript, getBuildPluginClasspathInjector().toList())
-
         def extraDependencies = extraGradleProperties.isEmpty() ? "" : NATIVE_CONFIG
         settingsFile << """
              buildscript {
@@ -180,7 +170,9 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     }
 
     private ProcessBuilder getProcessBuilder(String... tasks) {
-        List<String> arguments = ["./gradlew", "--init-script", String.format("./%s", INIT_FILE_NAME)]
+        File initScript = new File(projectDir, "init.gradle")
+        ClasspathAddingInitScriptBuilder.build(initScript, getBuildPluginClasspathInjector().toList())
+        List<String> arguments = ["./gradlew", "--init-script", initScript.toPath().toString()]
         Arrays.asList(tasks).forEach(arguments::add)
         ProcessBuilder processBuilder = new ProcessBuilder()
                 .command(arguments)

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -21,6 +21,7 @@ import spock.lang.Unroll
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
@@ -136,6 +137,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         ProcessBuilder processBuilder = getProcessBuilder(tasks)
         Process process = processBuilder.start()
         String output = readAllInput(process.getInputStream())
+        process.waitFor(1, TimeUnit.MINUTES)
         GradlewExecutionResult result = new GradlewExecutionResult(process.exitValue(), output)
         assert result.success
         return result
@@ -168,7 +170,8 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         Arrays.asList(tasks).forEach(arguments::add)
         ProcessBuilder processBuilder = new ProcessBuilder()
                 .command(arguments)
-                .directory(projectDir).redirectErrorStream(true)
+                .directory(projectDir)
+                .redirectErrorStream(true)
         return processBuilder
     }
 

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -74,12 +74,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
             apply plugin: 'com.palantir.baseline-java-versions'
             apply plugin: 'com.palantir.jdks'
             apply plugin: 'com.palantir.jdks.latest'
-            
-            dependencies {
-                palantirJavaFormat files(file("${CLASSPATH_FILE}").text.split(':')) 
-                ${extraDependencies}
-            }
-            
+
             javaVersions {
                 libraryTarget = ${javaVersion}
             }
@@ -100,13 +95,19 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         palantir.jdk.setup.enabled=true
         """.stripIndent()
         file('gradle.properties') << extraGradleProperties
+        runTasks('wrapper')
 
         buildFile << """
             apply plugin: 'com.diffplug.spotless'
+            
+            dependencies {
+                palantirJavaFormat files(file("${CLASSPATH_FILE}").text.split(':'))
+                ${extraDependencies}
+            }
         """.stripIndent()
 
         file('src/main/java/Main.java').text = invalidJavaFile
-        runTasks('wrapper', '--init-script', INIT_FILE_NAME)
+
 
         when:
         def result = runGradlewTasks('spotlessApply', '--info')

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -16,6 +16,8 @@
 package com.palantir.javaformat.gradle
 
 import nebula.test.IntegrationTestKitSpec
+import nebula.test.functional.GradleRunner
+import nebula.test.functional.internal.classpath.ClasspathAddingInitScriptBuilder
 import spock.lang.Unroll
 
 import java.nio.charset.StandardCharsets
@@ -28,10 +30,14 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     private static final CLASSPATH_FILE = new File("build/impl.classpath").absolutePath
     private static final NATIVE_IMAGE_FILE = new File("build/nativeImage.path")
     private static final NATIVE_CONFIG = String.format("palantirJavaFormatNative files(\"%s\")", NATIVE_IMAGE_FILE.text)
+    private static final String INIT_FILE_NAME = "init.gradle";
 
 
     @Unroll
     def "formats with spotless when spotless is applied"(String extraGradleProperties, String javaVersion, String expectedOutput) {
+        File initScript = new File(projectDir, INIT_FILE_NAME)
+        ClasspathAddingInitScriptBuilder.build(initScript, getBuildPluginClasspathInjector().toList())
+
         def extraDependencies = extraGradleProperties.isEmpty() ? "" : NATIVE_CONFIG
         settingsFile << """
              buildscript {
@@ -56,7 +62,6 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
                      classpath 'com.palantir.baseline:gradle-baseline-java:6.21.0'
                      classpath 'com.palantir.gradle.jdks:gradle-jdks:0.62.0'
                      classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.17.0'
-                     classpath files(FILES)
                  }
              }
 
@@ -71,21 +76,19 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
             apply plugin: 'com.palantir.jdks.latest'
             
             dependencies {
-                palantirJavaFormat files(file("${CLASSPATH_FILE}").text.split(':'))
-                EXTRA_CONFIGURATION
+                palantirJavaFormat files(file("${CLASSPATH_FILE}").text.split(':')) 
+                ${extraDependencies}
             }
             
             javaVersions {
-                libraryTarget = JAVA_VERSION
+                libraryTarget = ${javaVersion}
             }
             
             jdks {
-                daemonTarget = JAVA_VERSION
+                daemonTarget = ${javaVersion}
             }
             
-        """.replace("FILES", getBuildPluginClasspathInjector().join(","))
-                .replace("JAVA_VERSION", javaVersion)
-                .replace("EXTRA_CONFIGURATION", extraDependencies).stripIndent()
+        """.stripIndent()
 
         // Add jvm args to allow spotless and formatter gradle plugins to run with Java 16+
         file('gradle.properties') << """
@@ -103,7 +106,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         """.stripIndent()
 
         file('src/main/java/Main.java').text = invalidJavaFile
-        runTasks('wrapper')
+        runTasks('wrapper', '--init-script', INIT_FILE_NAME)
 
         when:
         def result = runGradlewTasks('spotlessApply', '--info')
@@ -131,7 +134,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
             properties.load(inputStream)
         }
         String classpath = properties.getProperty('implementation-classpath')
-        return classpath.split(File.pathSeparator).collect { "'" + it + "'" }
+        return classpath.split(File.pathSeparator).collect { new File(it) }
     }
 
     private String runGradlewTasks(String... tasks) {
@@ -149,7 +152,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
     }
 
     private ProcessBuilder getProcessBuilder(String... tasks) {
-        List<String> arguments = ["./gradlew"]
+        List<String> arguments = ["./gradlew", "--init-script", String.format("./%s", INIT_FILE_NAME)]
         Arrays.asList(tasks).forEach(arguments::add)
         ProcessBuilder processBuilder = new ProcessBuilder()
                 .command(arguments)

--- a/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
+++ b/gradle-palantir-java-format/src/test/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPluginTest.groovy
@@ -16,8 +16,12 @@
 package com.palantir.javaformat.gradle
 
 import nebula.test.IntegrationTestKitSpec
+import nebula.test.functional.ExecutionResult
 import nebula.test.functional.GradleRunner
+import nebula.test.functional.internal.DefaultExecutionResult
+import nebula.test.functional.internal.ExecutedTask
 import nebula.test.functional.internal.classpath.ClasspathAddingInitScriptBuilder
+import org.gradle.api.GradleException
 import spock.lang.Unroll
 
 import java.nio.charset.StandardCharsets
@@ -113,7 +117,7 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         def result = runGradlewTasks('spotlessApply', '--info')
 
         then:
-        result.contains(expectedOutput)
+        result.standardOutput.contains(expectedOutput)
         file('src/main/java/Main.java').text == validJavaFile
 
         where:
@@ -138,14 +142,37 @@ class PalantirJavaFormatSpotlessPluginTest extends IntegrationTestKitSpec {
         return classpath.split(File.pathSeparator).collect { new File(it) }
     }
 
-    private String runGradlewTasks(String... tasks) {
+    private GradlewExecutionResult runGradlewTasksAndFail(String... tasks) {
         ProcessBuilder processBuilder = getProcessBuilder(tasks)
         Process process = processBuilder.start()
-        String output = readAllInput(process.getInputStream())
-        return output
+        process.waitFor()
+        GradlewExecutionResult result = new GradlewExecutionResult(process)
+        assert result.failure
     }
 
-    public static String readAllInput(InputStream inputStream) {
+    private GradlewExecutionResult runGradlewTasks(String... tasks) {
+        ProcessBuilder processBuilder = getProcessBuilder(tasks)
+        Process process = processBuilder.start()
+        process.waitFor()
+        GradlewExecutionResult result = new GradlewExecutionResult(process)
+        assert result.success
+        return result
+    }
+
+    final class GradlewExecutionResult {
+
+        private final Boolean success
+        private final String standardOutput
+        private final Throwable failure
+
+        GradlewExecutionResult(Process process) {
+            this.success = process.exitValue() == 0
+            this.standardOutput =  readAllInput(process.getInputStream())
+            this.failure = process.exitValue() != 0 ? new RuntimeException(String.format("Build failed with exitCode %s", process.exitValue())) : null
+        }
+    }
+
+    static String readAllInput(InputStream inputStream) {
         try (Stream<String> lines =
                 new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()) {
             return lines.collect(Collectors.joining("\n"));


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The throughput for formatting big repos is decreased by using the native image (CE edition) - see internal metrics doc [here](https://pl.ntr/2sa) and [comment here](https://github.com/palantir/palantir-java-format/pull/1200#discussion_r1960098782)
java-based implementation [32 secs](https://pl.ntr/2qT) vs native-image implementation [1min 20sec](https://pl.ntr/2qS).

Even though spotlessApply is incremental and cacheable, in case the task cannot run incrementally, the performance is not good. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

When running `spotlessApply` tasks only  (to format full projects), we will switch to using: 
- Java-based implementation if the daemonTarget already is set to Java 21
- otherwise we will use the native-image until the rollout of Java 21 is finished everywhere.

formatDiff/Intellij will still use the native image formatter by default - the perf for running on a few files is better with native-image vs Java-based implementations.

==COMMIT_MSG==
SpotlessApply uses by default the Java formatter
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

