### PR TITLE
Fix pluginVersion discovery

### DIFF
--- a/changelog/@unreleased/pr-1247.v2.yml
+++ b/changelog/@unreleased/pr-1247.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix pluginVersion discovery
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1247

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 final class FormatterProvider {
     private static final Logger log = LoggerFactory.getLogger(FormatterProvider.class);
 
-    private static final String PLUGIN_ID = "palantir-java-format";
+    static final String PLUGIN_ID = "palantir-java-format";
 
     // Cache to avoid creating a URLClassloader every time we want to format from IntelliJ
     private final LoadingCache<FormatterCacheKey, Optional<FormatterService>> implementationCache =

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -60,6 +60,11 @@ final class FormatterProvider {
     private final LoadingCache<FormatterCacheKey, Optional<FormatterService>> implementationCache =
             Caffeine.newBuilder().maximumSize(1).build(FormatterProvider::createFormatter);
 
+    static IdeaPluginDescriptor getPluginDescriptor() {
+        return Preconditions.checkNotNull(
+                PluginManager.getPlugin(PluginId.getId(PLUGIN_ID)), "Couldn't find our own plugin: %s", PLUGIN_ID);
+    }
+
     Optional<FormatterService> get(Project project, PalantirJavaFormatSettings settings) {
         return implementationCache.get(new FormatterCacheKey(
                 project,
@@ -117,8 +122,7 @@ final class FormatterProvider {
     @SuppressWarnings("for-rollout:Slf4jLogsafeArgs")
     private static List<Path> getBundledImplementationUrls() {
         // Load from the jars bundled with the plugin.
-        IdeaPluginDescriptor ourPlugin = Preconditions.checkNotNull(
-                PluginManager.getPlugin(PluginId.getId(PLUGIN_ID)), "Couldn't find our own plugin: %s", PLUGIN_ID);
+        IdeaPluginDescriptor ourPlugin = getPluginDescriptor();
         Path implDir = ourPlugin.getPath().toPath().resolve("impl");
         log.debug("Using palantir-java-format implementation bundled with plugin: {}", implDir);
         return listDirAsUrlsUnchecked(implDir);

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -16,14 +16,10 @@
 
 package com.palantir.javaformat.intellij;
 
-import com.google.common.base.Preconditions;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.javaformat.java.JavaFormatterOptions;
@@ -115,11 +111,7 @@ public class PalantirJavaFormatSettings implements PersistentStateComponent<Pala
     }
 
     Optional<String> getImplementationVersion() {
-        IdeaPluginDescriptor ourPlugin = Preconditions.checkNotNull(
-                PluginManager.getPlugin(PluginId.getId(FormatterProvider.PLUGIN_ID)),
-                "Couldn't find our own plugin: %s",
-                FormatterProvider.PLUGIN_ID);
-        return Optional.ofNullable(ourPlugin.getVersion());
+        return Optional.ofNullable(FormatterProvider.getPluginDescriptor().getVersion());
     }
 
     Optional<String> computeFormatterVersion() {

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -16,11 +16,14 @@
 
 package com.palantir.javaformat.intellij;
 
-import com.google.common.base.Strings;
+import com.google.common.base.Preconditions;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.javaformat.java.JavaFormatterOptions;
@@ -112,8 +115,11 @@ public class PalantirJavaFormatSettings implements PersistentStateComponent<Pala
     }
 
     Optional<String> getImplementationVersion() {
-        return Optional.ofNullable(Strings.emptyToNull(
-                PalantirJavaFormatConfigurable.class.getPackage().getImplementationVersion()));
+        IdeaPluginDescriptor ourPlugin = Preconditions.checkNotNull(
+                PluginManager.getPlugin(PluginId.getId(FormatterProvider.PLUGIN_ID)),
+                "Couldn't find our own plugin: %s",
+                FormatterProvider.PLUGIN_ID);
+        return Optional.ofNullable(ourPlugin.getVersion());
     }
 
     Optional<String> computeFormatterVersion() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The logic of using the bundled/injected version doesn't work as expected. I think at some point the [logic that gets the version of the plugin ](https://github.com/palantir/palantir-java-format/compare/cr/fix-version?expand=1#diff-cfaa2a5a1981704685ebc0f2752eec605ccdb32fc40126b4cc05e1dfa27f900bL115) stopped returning a version - probably this was surfaced in [here](https://github.com/palantir/palantir-java-format/pull/644/files#diff-e7ad752a0f7a73390d1661fcc4aefc8038ca9564d30c6bd8520c5477276b557bR100) and now the implementation version is always `unknown`. This makes the logic to figure out whether to use the bundled impl or the injected impl always return the bundled impl - because the bundledImpl is an [Optional.empty](https://github.com/palantir/palantir-java-format/blob/d8845f8dba83a3f18c5c58a7e36d88bd3fe8fe97/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java#L106) hence we will always use the bundledImplementation.

<img width="978" alt="Screenshot 2025-03-20 at 2 16 59 PM" src="https://github.com/user-attachments/assets/da4ca733-80dc-40fe-9347-20f00e8ac1ae" />


## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Correctly figure out the version of the plugin.
<img width="1024" alt="Screenshot 2025-03-20 at 2 06 34 PM" src="https://github.com/user-attachments/assets/6f86e943-9f8d-4f88-a0bd-3389f98ff066" />

==COMMIT_MSG==
Fix pluginVersion discovery
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

