### PR TITLE
Allow selecting code style in Intellij plugin

### DIFF
--- a/changelog/@unreleased/pr-1256.v2.yml
+++ b/changelog/@unreleased/pr-1256.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Allow selecting code style in Intellij plugin
+  links:
+    - https://github.com/palantir/palantir-java-format/pull/1256
+

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -33,6 +33,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.bootstrap.NativeImageFormatterService;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions.Style;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -69,6 +70,7 @@ final class FormatterProvider {
         return implementationCache.get(new FormatterCacheKey(
                 project,
                 getSdkVersion(project),
+                settings.getStyle(),
                 settings.getImplementationClassPath(),
                 settings.getNativeImageClassPath(),
                 settings.injectedVersionIsOutdated()));
@@ -93,7 +95,8 @@ final class FormatterProvider {
                 jdkMajorVersion, ApplicationInfo.getInstance().getBuild())) {
             Path jdkPath = getJdkPath(cacheKey.project);
             log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
-            return Optional.of(new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath));
+            return Optional.of(new BootstrappingFormatterService(
+                    jdkPath, jdkMajorVersion, implementationClasspath, cacheKey.style));
         }
 
         // Use "in-process" formatter service
@@ -214,6 +217,7 @@ final class FormatterProvider {
     private static final class FormatterCacheKey {
         private final Project project;
         private final OptionalInt jdkMajorVersion;
+        private final Style style;
         private final Optional<List<URI>> implementationClassPath;
         private final Optional<URI> nativeImageClassPath;
         private final boolean useBundledImplementation;
@@ -221,11 +225,13 @@ final class FormatterProvider {
         FormatterCacheKey(
                 Project project,
                 OptionalInt jdkMajorVersion,
+                Style style,
                 Optional<List<URI>> implementationClassPath,
                 Optional<URI> nativeImageClassPath,
                 boolean useBundledImplementation) {
             this.project = project;
             this.jdkMajorVersion = jdkMajorVersion;
+            this.style = style;
             this.implementationClassPath = implementationClassPath;
             this.nativeImageClassPath = nativeImageClassPath;
             this.useBundledImplementation = useBundledImplementation;
@@ -243,6 +249,7 @@ final class FormatterProvider {
             return Objects.equals(jdkMajorVersion, that.jdkMajorVersion)
                     && useBundledImplementation == that.useBundledImplementation
                     && Objects.equals(project, that.project)
+                    && Objects.equals(style, that.style)
                     && Objects.equals(implementationClassPath, that.implementationClassPath)
                     && Objects.equals(nativeImageClassPath, that.nativeImageClassPath);
         }
@@ -250,7 +257,12 @@ final class FormatterProvider {
         @Override
         public int hashCode() {
             return Objects.hash(
-                    project, jdkMajorVersion, implementationClassPath, nativeImageClassPath, useBundledImplementation);
+                    project,
+                    jdkMajorVersion,
+                    style,
+                    implementationClassPath,
+                    nativeImageClassPath,
+                    useBundledImplementation);
         }
     }
 }

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/UiFormatterStyle.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/UiFormatterStyle.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 /** Configuration options for the formatting style. */
 enum UiFormatterStyle {
     PALANTIR("Default Palantir Java style", Style.PALANTIR),
+    GOOGLE("Default Google Java Style", Style.GOOGLE),
+    AOSP("AOSP-compliant Style", Style.AOSP),
     ;
 
     private final String description;

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.palantir.javaformat.java.FormatterException;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions.Style;
 import com.palantir.javaformat.java.Replacement;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -43,11 +44,18 @@ public final class BootstrappingFormatterService implements FormatterService {
     private final Path jdkPath;
     private final Integer jdkMajorVersion;
     private final List<Path> implementationClassPath;
+    private final Style style;
 
     public BootstrappingFormatterService(Path jdkPath, Integer jdkMajorVersion, List<Path> implementationClassPath) {
+        this(jdkPath, jdkMajorVersion, implementationClassPath, Style.PALANTIR);
+    }
+
+    public BootstrappingFormatterService(
+            Path jdkPath, Integer jdkMajorVersion, List<Path> implementationClassPath, Style style) {
         this.jdkPath = jdkPath;
         this.jdkMajorVersion = jdkMajorVersion;
         this.implementationClassPath = implementationClassPath;
+        this.style = style;
     }
 
     @Override
@@ -85,6 +93,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .implementationClasspath(implementationClassPath)
                 .outputReplacements(true)
                 .characterRanges(ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
+                .style(style)
                 .build();
 
         Optional<String> output = FormatterCommandRunner.runWithStdin(command.toArgs(), input);
@@ -100,6 +109,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .withJvmArgsForVersion(jdkMajorVersion)
                 .implementationClasspath(implementationClassPath)
                 .outputReplacements(false)
+                .style(style)
                 .build();
         return FormatterCommandRunner.runWithStdin(command.toArgs(), input).orElse(input);
     }
@@ -115,6 +125,8 @@ public final class BootstrappingFormatterService implements FormatterService {
         List<Path> implementationClasspath();
 
         List<String> jvmArgs();
+
+        Style style();
 
         default List<String> toArgs() {
             ImmutableList.Builder<String> args = ImmutableList.<String>builder()
@@ -134,9 +146,16 @@ public final class BootstrappingFormatterService implements FormatterService {
                 args.add("--output-replacements");
             }
 
+            switch (style()) {
+                case GOOGLE -> {}
+                case PALANTIR -> {
+                    args.add("--palantir");
+                }
+                case AOSP -> {
+                    args.add("--aosp");
+                }
+            }
             return args
-                    // Use palantir style
-                    .add("--palantir")
                     // Trailing "-" enables formatting stdin -> stdout
                     .add("-")
                     .build();


### PR DESCRIPTION
## Before this PR
Idea plugin users could not choose the code style (GOOGLE, PALANTIR vs AOSP) although this was allowed using the cli as well as the maven and gradle plugins.

## After this PR
The plugin allows users to select between the three supported code styles.

Closes #903 

## Possible downsides?
None that I can think of.

