### PR TITLE
Add formatter Intellij logs

### DIFF
--- a/changelog/@unreleased/pr-1263.v2.yml
+++ b/changelog/@unreleased/pr-1263.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add formatter Intellij logs
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1263

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Range;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.TextRange;
@@ -30,14 +31,17 @@ import com.intellij.psi.PsiFile;
 import com.palantir.javaformat.java.FormatterException;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.javaformat.java.Replacement;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 
 class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService {
+    private static final Logger logger = Logger.getInstance(PalantirJavaFormatFormattingService.class);
     private final FormatterProvider formatterProvider = new FormatterProvider();
 
     @Override
@@ -89,9 +93,20 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
             }
 
             try {
-                String formattedText = applyReplacements(
-                        request.getDocumentText(),
-                        formatterService.get().getFormatReplacements(request.getDocumentText(), toRanges(request)));
+                logger.info(String.format(
+                        "Received request to format file=%s, length=%s with ranges=%s",
+                        Optional.ofNullable(request.getIOFile())
+                                .map(file -> file.toPath().toString())
+                                .orElse("null"),
+                        request.getDocumentText().length(),
+                        request.getFormattingRanges()));
+                List<Replacement> replacements =
+                        formatterService.get().getFormatReplacements(request.getDocumentText(), toRanges(request));
+                logger.debug(String.format(
+                        "Applying %s replacements with ranges=%s",
+                        replacements.size(),
+                        replacements.stream().map(Replacement::getReplaceRange).collect(Collectors.toSet())));
+                String formattedText = applyReplacements(request.getDocumentText(), replacements);
                 request.onTextReady(formattedText);
             } catch (FormatterException e) {
                 request.onError(

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -31,7 +31,6 @@ import com.intellij.psi.PsiFile;
 import com.palantir.javaformat.java.FormatterException;
 import com.palantir.javaformat.java.FormatterService;
 import com.palantir.javaformat.java.Replacement;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -93,19 +92,25 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
             }
 
             try {
-                logger.info(String.format(
-                        "Received request to format file=%s, length=%s with ranges=%s",
-                        Optional.ofNullable(request.getIOFile())
-                                .map(file -> file.toPath().toString())
-                                .orElse("null"),
-                        request.getDocumentText().length(),
-                        request.getFormattingRanges()));
+                if (logger.isDebugEnabled()) {
+                    logger.debug(String.format(
+                            "Received request to format file=%s, length=%s with ranges=%s",
+                            Optional.ofNullable(request.getIOFile())
+                                    .map(file -> file.toPath().toString())
+                                    .orElse("null"),
+                            request.getDocumentText().length(),
+                            request.getFormattingRanges()));
+                }
                 List<Replacement> replacements =
                         formatterService.get().getFormatReplacements(request.getDocumentText(), toRanges(request));
-                logger.debug(String.format(
-                        "Applying %s replacements with ranges=%s",
-                        replacements.size(),
-                        replacements.stream().map(Replacement::getReplaceRange).collect(Collectors.toSet())));
+                if (logger.isDebugEnabled()) {
+                    logger.debug(String.format(
+                            "Applying %s replacements with ranges=%s",
+                            replacements.size(),
+                            replacements.stream()
+                                    .map(Replacement::getReplaceRange)
+                                    .collect(Collectors.toSet())));
+                }
                 String formattedText = applyReplacements(request.getDocumentText(), replacements);
                 request.onTextReady(formattedText);
             } catch (FormatterException e) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Intellij logs will show when a formatter request is sent to `palantir-java-format`. This should facilitate debugging issues like [here](https://pl.ntr/2sE) where intellij sometimes doesn't format long lines until a new empty line is added. 

to enable the debug log we need to: 
- Navigate to `Help | Diagnostic Tools | Debug Log Settings...`
- add `com.palantir.javaformat.intellij:all`

==COMMIT_MSG==
Add formatter Intellij logs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

