### PR TITLE
[PJF] Do not reflow text blocks

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
@@ -127,6 +127,10 @@ public final class StringWrapper {
                 if (literalTree.getKind() != Kind.STRING_LITERAL) {
                     return null;
                 }
+                int pos = getStartPosition(literalTree);
+                if (input.substring(pos, Math.min(input.length(), pos + 3)).equals("\"\"\"")) {
+                    return null;
+                }
                 Tree parent = getCurrentPath().getParentPath().getLeaf();
                 if (parent instanceof MemberSelectTree
                         && ((MemberSelectTree) parent).getExpression().equals(literalTree)) {
@@ -264,7 +268,7 @@ public final class StringWrapper {
      * @param first0 true if the text includes the beginning of its enclosing concat chain, i.e. a
      * @param textStartColumn the column position of the beginning of the original text
      * @param firstLineStartColumn the column where the very first line starts (can be less than textStartColumn if text
-     *     follows variable declaration)
+     * follows variable declaration)
      */
     private static String reflow(
             String separator,
@@ -415,5 +419,6 @@ public final class StringWrapper {
         return sb.toString();
     }
 
-    private StringWrapper() {}
+    private StringWrapper() {
+    }
 }

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/StringWrapperTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/StringWrapperTest.java
@@ -17,6 +17,7 @@ package com.palantir.javaformat.java;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Joiner;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -46,6 +47,26 @@ public class StringWrapperTest {
                 "}");
 
         assertThat(StringWrapper.wrap(100, input, Formatter.create())).isEqualTo(output);
+    }
+
+    @Test
+    public void textBlock() throws Exception {
+        Assumptions.assumeTrue(Formatter.getRuntimeVersion() >= 15);
+        String input =
+                lines(
+                        "package com.mypackage;",
+                        "public class ReproBug {",
+                        "    private String myString;",
+                        "    private ReproBug() {",
+                        "        String str =",
+                        "                \"\"\"",
+                        "               "
+                                + " {\"sourceEndpoint\":\"ri.something.1-1.object-internal.1\",\"targetEndpoint\":\"ri.some"
+                                + "thing.1-1.object-internal.2\",\"typeId\":\"typeId\"}\"\"\";",
+                        "        myString = str;",
+                        "    }",
+                        "}");
+        assertThat(StringWrapper.wrap(100, input, Formatter.create())).isEqualTo(input);
     }
 
     private static String lines(String... line) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
StringWrapper would attempt to reflow text blocks.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
StringWrapper does not attempt to reflow text blocks. Fixes https://github.com/palantir/palantir-java-format/issues/1205

https://github.com/google/google-java-format/commit/295e7a43f8a84d31c9e39fd853c8c4e52f586240

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

