### PR TITLE
Set working directory for the native image process

### DIFF
--- a/changelog/@unreleased/pr-1273.v2.yml
+++ b/changelog/@unreleased/pr-1273.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Set working directory for the native image process
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1273

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -114,6 +114,11 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
                 String formattedText = applyReplacements(request.getDocumentText(), replacements);
                 request.onTextReady(formattedText);
             } catch (FormatterException e) {
+                logger.error(
+                        String.format(
+                                "Failed to format file %s",
+                                request.getContext().getContainingFile().getName()),
+                        e);
                 request.onError(
                         Notifications.PARSING_ERROR_TITLE,
                         Notifications.parsingErrorMessage(

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -86,7 +86,9 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .outputReplacements(true)
                 .characterRanges(ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
                 .build();
-        Optional<String> output = FormatterCommandRunner.runWithStdin(command.toArgs(), input);
+
+        Optional<String> output =
+                FormatterCommandRunner.runWithStdin(command.toArgs(), input, Optional.of(jdkPath.getParent()));
         if (output.isEmpty() || output.get().isEmpty()) {
             return ImmutableList.of();
         }
@@ -100,7 +102,8 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .implementationClasspath(implementationClassPath)
                 .outputReplacements(false)
                 .build();
-        return FormatterCommandRunner.runWithStdin(command.toArgs(), input).orElse(input);
+        return FormatterCommandRunner.runWithStdin(command.toArgs(), input, Optional.ofNullable(jdkPath.getParent()))
+                .orElse(input);
     }
 
     @Value.Immutable

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -86,7 +86,6 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .outputReplacements(true)
                 .characterRanges(ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
                 .build();
-
         Optional<String> output = FormatterCommandRunner.runWithStdin(command.toArgs(), input);
         if (output.isEmpty() || output.get().isEmpty()) {
             return ImmutableList.of();

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
@@ -60,7 +60,7 @@ final class FormatterCommandRunner {
                 // In this case, we just want to silently do nothing and not surface an error to e.g. Intellij.
                 return Optional.empty();
             }
-            throw new IOException(getErrorMessage(command, stdout, stderr));
+            throw new IOException(getErrorMessage(command, workingDirectory, stdout, stderr));
         }
 
         return Optional.of(stdout);
@@ -80,11 +80,13 @@ final class FormatterCommandRunner {
         }
     }
 
-    private static String getErrorMessage(List<String> command, String stdout, String stderr) {
+    private static String getErrorMessage(
+            List<String> command, Optional<Path> workingDirectory, String stdout, String stderr) {
         return String.join(
                 "\n",
                 "Command terminated with exit value 1",
                 "Command: " + String.join(" ", command),
+                "Working Directory: " + workingDirectory,
                 "Stdout:",
                 stdout,
                 "Stderr:",

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
@@ -86,7 +86,8 @@ final class FormatterCommandRunner {
                 "\n",
                 "Command terminated with exit value 1",
                 "Command: " + String.join(" ", command),
-                "Working Directory: " + workingDirectory,
+                "Working Directory: "
+                        + workingDirectory.map(Path::toString).orElse("<using default working directory>"),
                 "Stdout:",
                 stdout,
                 "Stderr:",

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
@@ -28,10 +28,6 @@ import java.util.regex.Pattern;
 final class FormatterCommandRunner {
     private static final Pattern SYNTAX_ERROR_PATTERN = Pattern.compile(":\\d+:\\d+:\\serror:\\s");
 
-    static Optional<String> runWithStdin(List<String> command, String input) throws IOException {
-        return runWithStdin(command, input, Optional.empty());
-    }
-
     static Optional<String> runWithStdin(List<String> command, String input, Optional<Path> workingDirectory)
             throws IOException {
         ProcessBuilder processBuilder = new ProcessBuilder().command(command);

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/FormatterCommandRunner.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -28,7 +29,16 @@ final class FormatterCommandRunner {
     private static final Pattern SYNTAX_ERROR_PATTERN = Pattern.compile(":\\d+:\\d+:\\serror:\\s");
 
     static Optional<String> runWithStdin(List<String> command, String input) throws IOException {
-        Process process = new ProcessBuilder().command(command).start();
+        return runWithStdin(command, input, Optional.empty());
+    }
+
+    static Optional<String> runWithStdin(List<String> command, String input, Optional<Path> workingDirectory)
+            throws IOException {
+        ProcessBuilder processBuilder = new ProcessBuilder().command(command);
+        Process process = workingDirectory
+                .map(dir -> processBuilder.directory(dir.toFile()))
+                .orElse(processBuilder)
+                .start();
 
         try (OutputStream outputStream = process.getOutputStream()) {
             outputStream.write(input.getBytes(StandardCharsets.UTF_8));

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
@@ -52,7 +52,8 @@ public class NativeImageFormatterService implements FormatterService {
                             ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
                     .build();
 
-            Optional<String> output = FormatterCommandRunner.runWithStdin(command.toArgs(), input);
+            Optional<String> output = FormatterCommandRunner.runWithStdin(
+                    command.toArgs(), input, Optional.ofNullable(nativeImagePath.getParent()));
             if (output.isEmpty() || output.get().isEmpty()) {
                 return ImmutableList.of();
             }
@@ -85,7 +86,9 @@ public class NativeImageFormatterService implements FormatterService {
                 .nativeImagePath(nativeImagePath)
                 .outputReplacements(false)
                 .build();
-        return FormatterCommandRunner.runWithStdin(command.toArgs(), input).orElse(input);
+        return FormatterCommandRunner.runWithStdin(
+                        command.toArgs(), input, Optional.ofNullable(nativeImagePath.getParent()))
+                .orElse(input);
     }
 
     @Value.Immutable


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Internal discussion [here](https://pl.ntr/2sQ).

Formatting a file failed with: 

```
Caused by: java.io.IOException: Command terminated with exit value 1
Command: /Users/crogoz/.gradle/caches/8.12.1/transforms/01a62203842d4c031584cf68fe01271a/transformed/palantir-java-format-native-2.61.0-nativeImage-macos_aarch64.bin.executable --character-ranges 0:2243 --output-replacements --palantir -
Stdout:

Stderr:
Exception in thread "main" java.lang.Error: Properties init: Could not determine current working directory.
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userDirValue(PosixSystemPropertiesSupport.java:62)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.userDir(SystemPropertiesSupport.java:268)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:237)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.ensureFullyInitialized(SystemPropertiesSupport.java:161)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperties(SystemPropertiesSupport.java:177)
	at java.base@23.0.1/java.lang.System.getProperties(System.java:380)
	at java.base@23.0.1/sun.security.action.GetPropertyAction.privilegedGetProperties(GetPropertyAction.java:154)
	at java.base@23.0.1/java.util.TimeZone.setDefaultZone(TimeZone.java:695)
	at java.base@23.0.1/java.util.TimeZone.getDefaultRef(TimeZone.java:685)
	at java.base@23.0.1/java.util.TimeZone.getDefault(TimeZone.java:674)
	at java.base@23.0.1/java.util.Calendar.defaultTimeZone(Calendar.java:1685)
	at java.base@23.0.1/java.util.Calendar.getInstance(Calendar.java:1665)
	at java.base@23.0.1/java.text.SimpleDateFormat.initializeCalendar(SimpleDateFormat.java:680)
	at java.base@23.0.1/java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:624)
	at com.fasterxml.jackson.databind.util.StdDateFormat.<clinit>(StdDateFormat.java:116)
	at com.fasterxml.jackson.databind.ObjectMapper.<clinit>(ObjectMapper.java:411)
	at java.base@23.0.1/java.lang.Class.ensureInitialized(DynamicHub.java:650)
	at com.palantir.javaformat.java.FormatFileCallable.<init>(FormatFileCallable.java:31)
	at com.palantir.javaformat.java.Main.formatStdin(Main.java:196)
	at com.palantir.javaformat.java.Main.format(Main.java:104)
	at com.palantir.javaformat.java.Main.main(Main.java:70)
	at java.base@23.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)

	at com.palantir.javaformat.bootstrap.FormatterCommandRunner.runWithStdin(FormatterCommandRunner.java:53)
	at com.palantir.javaformat.bootstrap.NativeImageFormatterService.getFormatReplacements(NativeImageFormatterService.java:55)
	... 34 more
```

The error happens if the current working directory is not valid: https://stackoverflow.com/a/14520176

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Attempting to set the working directory when the native image process runs. The workingDirectory will be set to the nativeImage's parent directory (which we know it exists).

==COMMIT_MSG==
Set working directory for the native image process
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

