### PR TITLE
[PJF] Do not reflow text blocks

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/StringWrapper.java
@@ -127,6 +127,10 @@ public final class StringWrapper {
                 if (literalTree.getKind() != Kind.STRING_LITERAL) {
                     return null;
                 }
+                int pos = getStartPosition(literalTree);
+                if (input.substring(pos, Math.min(input.length(), pos + 3)).equals("\"\"\"")) {
+                    return null;
+                }
                 Tree parent = getCurrentPath().getParentPath().getLeaf();
                 if (parent instanceof MemberSelectTree
                         && ((MemberSelectTree) parent).getExpression().equals(literalTree)) {

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/StringWrapperTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/StringWrapperTest.java
@@ -15,6 +15,7 @@
 package com.palantir.javaformat.java;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Joiner;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,25 @@ public class StringWrapperTest {
                 "}");
 
         assertThat(StringWrapper.wrap(100, input, Formatter.create())).isEqualTo(output);
+    }
+
+    @Test
+    public void textBlock() throws Exception {
+        assumeTrue(Formatter.getRuntimeVersion() >= 15);
+        String input = lines(
+                "package com.mypackage;",
+                "public class ReproBug {",
+                "    private String myString;",
+                "    private ReproBug() {",
+                "        String str =",
+                "                \"\"\"",
+                "               "
+                        + " {\"sourceEndpoint\":\"ri.something.1-1.object-internal.1\",\"targetEndpoint\":\"ri.some"
+                        + "thing.1-1.object-internal.2\",\"typeId\":\"typeId\"}\"\"\";",
+                "        myString = str;",
+                "    }",
+                "}");
+        assertThat(StringWrapper.wrap(100, input, Formatter.create())).isEqualTo(input);
     }
 
     private static String lines(String... line) {


### PR DESCRIPTION
Adds upstream fix https://github.com/google/google-java-format/commit/295e7a43f8a84d31c9e39fd853c8c4e52f586240

## Before this PR
Formatting a textblock which
- exceeds the max line length
- has no trailing newline (ie. """ is at the end of the line)

Causes the formatter to fail:
```
error: Something has gone terribly wrong. Please file a bug: https://github.com/palantir/palantir-java-format/issues/new

=== Actual: ===
package com.test;

public class MyTest {
    private String myString = "A very long string which just so happens to exceed the max line length and doesn't\"\n    + \" have a trailing newline";
}
=== Expected: ===
package com.test;

public class MyTest {
    private String myString = "A very long string which just so happens to exceed the max line length and doesn't have a trailing newline";
}

```

## After this PR
Formatter doesn't fail, Fixes https://github.com/palantir/palantir-java-format/issues/1205
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

