### PR TITLE
currently requires restart to update

### DIFF
--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin url="https://github.com/palantir/palantir-java-format" require-restart="false">
+<idea-plugin url="https://github.com/palantir/palantir-java-format" require-restart="true">
   <id>palantir-java-format</id>
   <name>palantir-java-format</name>
   <vendor url="https://github.com/palantir/palantir-java-format">


### PR DESCRIPTION
## Before this PR
Had set `requires-restart` to false even though this is not true and caused dynamic unload errors

## After this PR
now correctly mark it as true

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
currently requires restart to update
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

