### PR TITLE
Use recommended project.getService & update sinceBuild to match intellij version

### DIFF
--- a/changelog/@unreleased/pr-1295.v2.yml
+++ b/changelog/@unreleased/pr-1295.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: Use recommended project.getService(PalantirJavaFormatSettings.class)
+  description: Use recommended project.getService & update sinceBuild to match intellij
+    version
   links:
   - https://github.com/palantir/palantir-java-format/pull/1295

--- a/changelog/@unreleased/pr-1295.v2.yml
+++ b/changelog/@unreleased/pr-1295.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use recommended project.getService(PalantirJavaFormatSettings.class)
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1295

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -27,7 +27,7 @@ intellij {
 
 patchPluginXml {
     pluginDescription = "Formats source code using the palantir-java-format tool."
-    sinceBuild = '241' // TODO: test against this version of IntelliJ to ensure no regressions
+    sinceBuild = '241' // TODO: keep the intellij version & sinceBuild in sync
     untilBuild = ''
 }
 

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -27,7 +27,7 @@ intellij {
 
 patchPluginXml {
     pluginDescription = "Formats source code using the palantir-java-format tool."
-    sinceBuild = '213' // TODO: test against this version of IntelliJ to ensure no regressions
+    sinceBuild = '241' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
 }
 

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -17,7 +17,6 @@
 package com.palantir.javaformat.intellij;
 
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
@@ -43,7 +42,7 @@ public class PalantirJavaFormatSettings implements PersistentStateComponent<Pala
     private State state = new State();
 
     static PalantirJavaFormatSettings getInstance(Project project) {
-        return ServiceManager.getService(project, PalantirJavaFormatSettings.class);
+        return project.getService(PalantirJavaFormatSettings.class);
     }
 
     @SuppressWarnings("for-rollout:SameNameButDifferent")


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
After the plugin was updated (live-reloadable), I am getting the following error in Intellij: 
```
java.lang.ClassCastException: class com.palantir.javaformat.intellij.PalantirJavaFormatSettings cannot be cast to class com.palantir.javaformat.intellij.PalantirJavaFormatSettings (com.palantir.javaformat.intellij.PalantirJavaFormatSettings is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @fc6a05b; com.palantir.javaformat.intellij.PalantirJavaFormatSettings is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @106bfe72)
	at com.palantir.javaformat.intellij.PalantirJavaFormatSettings.getInstance(PalantirJavaFormatSettings.java:46)
	at com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable.isModified(PalantirJavaFormatConfigurable.java:108)
	at com.intellij.openapi.options.ex.ConfigurableWrapper.isModified(ConfigurableWrapper.java:185)
	at com.intellij.openapi.options.newEditor.SettingsEditor.checkModifiedInternal(SettingsEditor.java:639)
	at com.intellij.openapi.options.newEditor.SettingsEditor.checkModifiedForItem(SettingsEditor.java:634)
	at com.intellij.openapi.options.newEditor.SettingsEditor.checkModified(SettingsEditor.java:623)
	at com.intellij.openapi.options.newEditor.SettingsEditor$6.onSelected(SettingsEditor.java:201)
	at com.intellij.openapi.options.newEditor.OptionsEditorContext$fireSelected$1.process(OptionsEditorContext.kt:43)
	at com.intellij.openapi.options.newEditor.OptionsEditorContext.notify(OptionsEditorContext.kt:92)
	at com.intellij.openapi.options.newEditor.OptionsEditorContext.fireSelected(OptionsEditorContext.kt:41)
	at com.intellij.openapi.options.newEditor.SettingsTreeView.fireSelected(SettingsTreeView.java:475)
	at com.intellij.openapi.options.newEditor.SettingsTreeView.lambda$new$0(SettingsTreeView.java:197)
	at java.desktop/javax.swing.tree.DefaultTreeSelectionModel
```

## After this PR

<!-- User-facing outcomes this PR delivers go below -->
- According to [jetbrains issue](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360009931280-ClassCastException-due-to-PluginClassLoader?page=1#community_comment_360002424100), we should keep the sinceBuild & intellij version in sync.
- `ServiceManager.getService` is deprecated, we should use `project.getService` instead
==COMMIT_MSG==
Use recommended project.getService & update sinceBuild to match intellij version
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

