### PR TITLE
bump `gradle-idea-configuration` and move off deprecated methods

### DIFF
--- a/changelog/@unreleased/pr-1298.v2.yml
+++ b/changelog/@unreleased/pr-1298.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: bump `gradle-idea-configuration` and move off deprecated methods
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1298

--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatIdeaPlugin.java
@@ -64,7 +64,9 @@ public final class PalantirJavaFormatIdeaPlugin implements Plugin<Project> {
 
         rootProject.getPluginManager().apply(IdeaConfigurationPlugin.class);
         IdeaConfigurationExtension extension = rootProject.getExtensions().getByType(IdeaConfigurationExtension.class);
-        extension.externalDependency("palantir-java-format", MIN_IDEA_PLUGIN_VERSION);
+        extension
+                .getExternalDependencies()
+                .register("palantir-java-format", dep -> dep.atLeastVersion(MIN_IDEA_PLUGIN_VERSION));
     }
 
     private static Optional<Configuration> maybeGetNativeImplConfiguration(Project rootProject) {

--- a/versions.lock
+++ b/versions.lock
@@ -23,7 +23,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 com.google.j2objc:j2objc-annotations:3.0.0 (2 constraints: ee163332)
 com.googlecode.concurrent-trees:concurrent-trees:2.6.1 (1 constraints: 761166da)
 com.googlecode.javaewah:JavaEWAH:1.2.3 (1 constraints: 460e7e50)
-com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.2.0 (1 constraints: 0405f135)
+com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.3.0 (1 constraints: 0505f435)
 com.palantir.gradle.utils:platform:0.10.0 (1 constraints: 3305233b)
 com.squareup.okhttp3:okhttp:4.12.0 (1 constraints: f6093eb3)
 com.squareup.okio:okio:3.6.0 (1 constraints: 530c38fd)

--- a/versions.props
+++ b/versions.props
@@ -22,4 +22,4 @@ com.fasterxml.jackson.*:* = 2.18.3
 com.fasterxml.jackson.core:jackson-databind = 2.18.3
 org.openjdk.jmh:* = 1.37
 com.palantir.gradle.utils:* = 0.10.0
-com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.2.0
+com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.3.0


### PR DESCRIPTION
## Before this PR
On version `0.2.0`

## After this PR
On version `0.3.0` and not using deprecated `externalDependency` method

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
bump `gradle-idea-configuration` and move off deprecated methods
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

