### PR TITLE
fix: support JDK 25 API change

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInput.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInput.java
@@ -48,7 +48,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
@@ -477,19 +476,19 @@ public final class JavaInput extends Input {
     @SuppressWarnings("unchecked")
     private static Collection<JCDiagnostic> getDiagnostics(DeferredDiagnosticHandler handler) {
         try {
-            // Try the JDK 25+ method first (List<JCDiagnostic>)
-            Method listMethod = DeferredDiagnosticHandler.class.getMethod("getDiagnostics");
-            return (Collection<JCDiagnostic>) listMethod.invoke(handler);
-        } catch (Exception e1) {
-            try {
-                // Fall back to pre-JDK 25 method (Queue<JCDiagnostic>)
-                Method queueMethod = DeferredDiagnosticHandler.class.getMethod("getDiagnostics");
-                return (Collection<JCDiagnostic>) queueMethod.invoke(handler);
-            } catch (Exception e2) {
-                // If all else fails, return empty collection
-                System.err.println("Unable to access diagnostics: " + e2.getMessage());
-                return Collections.emptyList();
-            }
+            return (Collection<JCDiagnostic>) GET_DIAGNOSTICS.invoke(handler);
+        } catch (ReflectiveOperationException e) {
+            throw new LinkageError(e.getMessage(), e);
+        }
+    }
+
+    private static final Method GET_DIAGNOSTICS;
+
+    static {
+        try {
+            GET_DIAGNOSTICS = DeferredDiagnosticHandler.class.getMethod("getDiagnostics");
+        } catch (NoSuchMethodException e) {
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInput.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInput.java
@@ -39,13 +39,16 @@ import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Log.DeferredDiagnosticHandler;
 import com.sun.tools.javac.util.Options;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
@@ -365,7 +368,7 @@ public final class JavaInput extends Input {
         });
         DeferredDiagnosticHandler diagnostics = new DeferredDiagnosticHandler(log);
         ImmutableList<RawTok> rawToks = JavacTokens.getTokens(text, context, stopTokens);
-        if (diagnostics.getDiagnostics().stream().anyMatch(d -> d.getKind() == Diagnostic.Kind.ERROR)) {
+        if (getDiagnostics(diagnostics).stream().anyMatch(d -> d.getKind() == Diagnostic.Kind.ERROR)) {
             return ImmutableList.of(new Tok(0, "", "", 0, 0, true, null)); // EOF
         }
         int kN = 0;
@@ -460,6 +463,33 @@ public final class JavaInput extends Input {
         }
         toks.add(new Tok(kN, "", "", charI, columnI, true, null)); // EOF tok.
         return ImmutableList.copyOf(toks);
+    }
+
+    /**
+     * Gets diagnostics from a DeferredDiagnosticHandler using reflection.
+     * This method handles the API change in JDK 25 where getDiagnostics()
+     * changed from returning Queue to List.
+     *
+     * @param handler the diagnostic handler
+     * @return a collection of diagnostics
+     */
+    @SuppressWarnings("unchecked")
+    private static Collection<JCDiagnostic> getDiagnostics(DeferredDiagnosticHandler handler) {
+        try {
+            // Try the JDK 25+ method first (List<JCDiagnostic>)
+            Method listMethod = DeferredDiagnosticHandler.class.getMethod("getDiagnostics");
+            return (Collection<JCDiagnostic>) listMethod.invoke(handler);
+        } catch (Exception e1) {
+            try {
+                // Fall back to pre-JDK 25 method (Queue<JCDiagnostic>)
+                Method queueMethod = DeferredDiagnosticHandler.class.getMethod("getDiagnostics");
+                return (Collection<JCDiagnostic>) queueMethod.invoke(handler);
+            } catch (Exception e2) {
+                // If all else fails, return empty collection
+                System.err.println("Unable to access diagnostics: " + e2.getMessage());
+                return Collections.emptyList();
+            }
+        }
     }
 
     private static int updateColumn(int columnI, String originalTokText) {


### PR DESCRIPTION
## Before this PR
The build fails with the following error when running on JDK 25
```
[INFO] --- spotless:2.44.4:apply (default) @ jline-native ---
[INFO] Index file corresponds to a different configuration of the plugin. Either the plugin version or its configuration has changed. Fallback to an empty index
[ERROR] Step 'palantir-java-format' found problem in 'JLineNativeLoaderTest.java':
'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
java.lang.NoSuchMethodError: 'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
    at com.palantir.javaformat.java.JavaInput.buildToks(JavaInput.java:368)
    at com.palantir.javaformat.java.ImportOrderer.reorderImports(ImportOrderer.java:49)
    at com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFunc.apply(PalantirJavaFormatFormatterFunc.java:53)
    at com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)
    at com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)
    at com.diffplug.spotless.Formatter.computeWithLint(Formatter.java:170)
    at com.diffplug.spotless.Formatter.compute(Formatter.java:135)
    at com.diffplug.spotless.generic.FenceStep$BaseFormatter.applyWithFile(FenceStep.java:229)
    at com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:174)
    at com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)
    at com.diffplug.spotless.Formatter.computeWithLint(Formatter.java:170)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:97)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:82)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:77)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:73)
    at com.diffplug.spotless.maven.SpotlessApplyMojo.process(SpotlessApplyMojo.java:63)
    at com.diffplug.spotless.maven.AbstractSpotlessMojo.execute(AbstractSpotlessMojo.java:255)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:146)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:339)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:310)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:214)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:179)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:168)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:165)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:110)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:60)
    at org.apache.maven.lifecycle.internal.DefaultLifecycleStarter.execute(DefaultLifecycleStarter.java:123)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:311)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:225)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:149)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.doExecute(MavenInvoker.java:462)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:100)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:81)
    at org.apache.maven.cling.invoker.LookupInvoker.doInvoke(LookupInvoker.java:165)
    at org.apache.maven.cling.invoker.LookupInvoker.invoke(LookupInvoker.java:135)
    at org.apache.maven.cling.ClingSupport.run(ClingSupport.java:76)
    at org.apache.maven.cling.MavenCling.main(MavenCling.java:51)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke(Method.java:565)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
[ERROR] Step 'toggle' found problem in 'JLineNativeLoaderTest.java':
'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
java.lang.NoSuchMethodError: 'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
    at com.palantir.javaformat.java.JavaInput.buildToks(JavaInput.java:368)
    at com.palantir.javaformat.java.ImportOrderer.reorderImports(ImportOrderer.java:49)
    at com.diffplug.spotless.glue.pjf.PalantirJavaFormatFormatterFunc.apply(PalantirJavaFormatFormatterFunc.java:53)
    at com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:33)
    at com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)
    at com.diffplug.spotless.Formatter.computeWithLint(Formatter.java:170)
    at com.diffplug.spotless.Formatter.compute(Formatter.java:135)
    at com.diffplug.spotless.generic.FenceStep$BaseFormatter.applyWithFile(FenceStep.java:229)
    at com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:174)
    at com.diffplug.spotless.FormatterStepEqualityOnStateSerialization.format(FormatterStepEqualityOnStateSerialization.java:49)
    at com.diffplug.spotless.Formatter.computeWithLint(Formatter.java:170)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:97)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:82)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:77)
    at com.diffplug.spotless.DirtyState.of(DirtyState.java:73)
    at com.diffplug.spotless.maven.SpotlessApplyMojo.process(SpotlessApplyMojo.java:63)
    at com.diffplug.spotless.maven.AbstractSpotlessMojo.execute(AbstractSpotlessMojo.java:255)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:146)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:339)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:310)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:214)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:179)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:168)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:165)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:110)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:60)
    at org.apache.maven.lifecycle.internal.DefaultLifecycleStarter.execute(DefaultLifecycleStarter.java:123)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:311)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:225)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:149)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.doExecute(MavenInvoker.java:462)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:100)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:81)
    at org.apache.maven.cling.invoker.LookupInvoker.doInvoke(LookupInvoker.java:165)
    at org.apache.maven.cling.invoker.LookupInvoker.invoke(LookupInvoker.java:135)
    at org.apache.maven.cling.ClingSupport.run(ClingSupport.java:76)
    at org.apache.maven.cling.MavenCling.main(MavenCling.java:51)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke(Method.java:565)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
```

## After this PR
The build works correctly


## Possible downsides?
The commit uses reflection to call the correct method, but this is the only way to support the incompatible API change introduced in JDK 25 while still supporting older JDK.

