### PR TITLE
Support for var in record patterns

### DIFF
--- a/changelog/@unreleased/pr-1312.v2.yml
+++ b/changelog/@unreleased/pr-1312.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Support for var in record patterns
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1312

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -115,7 +115,7 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
         return null;
     }
 
-    protected void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
+    private void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
         builder.open(plusFour);
         if (modifiers != null) {
             builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -115,7 +115,7 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
         return null;
     }
 
-    private void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
+    protected void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
         builder.open(plusFour);
         if (modifiers != null) {
             builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java14/Java14InputAstVisitor.java
@@ -120,7 +120,11 @@ public class Java14InputAstVisitor extends JavaInputAstVisitor {
         if (modifiers != null) {
             builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));
         }
-        scan(type, null);
+        if (type == null) {
+            token("var");
+        } else {
+            scan(type, null);
+        }
         builder.breakOp(" ");
         if (name.isEmpty()) {
             token("_");

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
@@ -23,8 +23,12 @@ import com.sun.source.tree.ConstantCaseLabelTree;
 import com.sun.source.tree.DeconstructionPatternTree;
 import com.sun.source.tree.DefaultCaseLabelTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.PatternCaseLabelTree;
 import com.sun.source.tree.PatternTree;
+import com.sun.source.tree.Tree;
+import java.util.Optional;
+import javax.lang.model.element.Name;
 
 /**
  * Extends {@link Java14InputAstVisitor} with support for AST nodes that were added or modified in
@@ -77,5 +81,25 @@ public class Java21InputAstVisitor extends Java14InputAstVisitor {
         builder.close();
         token(")");
         return null;
+    }
+
+    @Override
+    protected void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
+        builder.open(plusFour);
+        if (modifiers != null) {
+            builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));
+        }
+        if (type == null) {
+            token("var");
+        } else {
+            scan(type, null);
+        }
+        builder.breakOp(" ");
+        if (name.isEmpty()) {
+            token("_");
+        } else {
+            visit(name);
+        }
+        builder.close();
     }
 }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
@@ -23,12 +23,8 @@ import com.sun.source.tree.ConstantCaseLabelTree;
 import com.sun.source.tree.DeconstructionPatternTree;
 import com.sun.source.tree.DefaultCaseLabelTree;
 import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.PatternCaseLabelTree;
 import com.sun.source.tree.PatternTree;
-import com.sun.source.tree.Tree;
-import java.util.Optional;
-import javax.lang.model.element.Name;
 
 /**
  * Extends {@link Java14InputAstVisitor} with support for AST nodes that were added or modified in
@@ -81,25 +77,5 @@ public class Java21InputAstVisitor extends Java14InputAstVisitor {
         builder.close();
         token(")");
         return null;
-    }
-
-    @Override
-    protected void visitBindingPattern(ModifiersTree modifiers, Tree type, Name name) {
-        builder.open(plusFour);
-        if (modifiers != null) {
-            builder.addAll(visitModifiers(modifiers, Direction.HORIZONTAL, Optional.empty()));
-        }
-        if (type == null) {
-            token("var");
-        } else {
-            scan(type, null);
-        }
-        builder.breakOp(" ");
-        if (name.isEmpty()) {
-            token("_");
-        } else {
-            visit(name);
-        }
-        builder.close();
     }
 }

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
@@ -50,7 +50,14 @@ public final class FileBasedTests {
                     .putAll(15, "I603")
                     .putAll(16, "I588")
                     .putAll(17, "I683", "I684", "I696")
-                    .putAll(21, "SwitchGuardClause", "SwitchRecord", "SwitchDouble", "SwitchUnderscore", "I880")
+                    .putAll(
+                            21,
+                            "SwitchGuardClause",
+                            "SwitchRecord",
+                            "SwitchDouble",
+                            "SwitchUnderscore",
+                            "I880",
+                            "I1309")
                     .build();
 
     private final Class<?> testClass;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.input
@@ -2,7 +2,7 @@ public class I1309 {
   void x(Object o) {
     if (o instanceof Record(Nested(var i), var j)) {}
     switch (o) {
-      case Record(Nested(var i), var j, var k, var l, var m, var n, var o, var p, var q, var r, var s, var t, var u, var v, var w, var x, var y, var z):
+      case Record(Nested(var i), var j, int k, char l, java.lang.String m, var n, var o, var p, var q, var r, var s, var t, var u, var v, var w, var x, var y, var z):
       default:
     }
   }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.input
@@ -1,0 +1,9 @@
+public class I1309 {
+  void x(Object o) {
+    if (o instanceof Record(Nested(var i), var j)) {}
+    switch (o) {
+      case Record(Nested(var i), var j, var k, var l, var m, var n, var o, var p, var q, var r, var s, var t, var u, var v, var w, var x, var y, var z):
+      default:
+    }
+  }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.output
@@ -1,0 +1,27 @@
+public class I1309 {
+    void x(Object o) {
+        if (o instanceof Record(Nested(var i), var j)) {}
+        switch (o) {
+            case Record(
+                    Nested(var i),
+                    var j,
+                    var k,
+                    var l,
+                    var m,
+                    var n,
+                    var o,
+                    var p,
+                    var q,
+                    var r,
+                    var s,
+                    var t,
+                    var u,
+                    var v,
+                    var w,
+                    var x,
+                    var y,
+                    var z):
+            default:
+        }
+    }
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/I1309.output
@@ -5,9 +5,9 @@ public class I1309 {
             case Record(
                     Nested(var i),
                     var j,
-                    var k,
-                    var l,
-                    var m,
+                    int k,
+                    char l,
+                    java.lang.String m,
                     var n,
                     var o,
                     var p,


### PR DESCRIPTION
## Before this PR
palantir fails when parsing source files with `var` inside a record pattern.
e.g.
```java
if (o instanceof Record(var i)) {}
switch (o) {
  case Record(var i):
}
```

## After this PR
Added support for `var` in record patterns.
The AST explicitly unsets the type when it sees `var`.
We may assume that's the reason `type` is `null`, so we just output "var".
Fixes #1309 

## Possible downsides?
The `type` is set to `null` when the token found is `var`, might change in the future?
There's a `declaredUsingVar` but it's false, might be broken (including java 24)