### PR TITLE
Output unnamed variables

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -342,7 +342,8 @@ public final class OpsBuilder {
             Indent plusIndentCommentsBefore,
             Optional<Indent> breakAndIndentTrailingComment) {
         ImmutableList<? extends Input.Token> tokens = input.getTokens();
-        if (token.equals(peekToken().orElse(null)) || (token.isEmpty() && peekToken().equals(Optional.of("_")))) { // Found the input token. Output it.
+        if (token.equals(peekToken().orElse(null))
+                || (token.isEmpty() && peekToken().equals(Optional.of("_")))) { // Found the input token. Output it.
             add(Token.make(
                     tokens.get(tokenI++),
                     RealOrImaginary.REAL,

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/OpsBuilder.java
@@ -342,7 +342,7 @@ public final class OpsBuilder {
             Indent plusIndentCommentsBefore,
             Optional<Indent> breakAndIndentTrailingComment) {
         ImmutableList<? extends Input.Token> tokens = input.getTokens();
-        if (token.equals(peekToken().orElse(null))) { // Found the input token. Output it.
+        if (token.equals(peekToken().orElse(null)) || (token.isEmpty() && peekToken().equals(Optional.of("_")))) { // Found the input token. Output it.
             add(Token.make(
                     tokens.get(tokenI++),
                     RealOrImaginary.REAL,


### PR DESCRIPTION
## Before this PR
Exception is thrown when there are unnamed variables in source code (issue: https://github.com/palantir/palantir-java-format/issues/1236).

The error is like, "com.palantir.javaformat.java.FormatterException: 217:106: error: expected token: '_'; generated  instead".

The cases we have seen include:

- unnamed var in try-with blocks, 
`try (var _ = abc) {}`
- unnamed argument in lambda
`(a, _) -> {}`

## After this PR
The source code can be formatted properly when containing unnamed variables.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

