### PR TITLE
Fix comments after default switch case expressions

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -1854,6 +1854,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     }
 
     protected void visitSwitch(ExpressionTree expression, List<? extends CaseTree> cases) {
+        builder.open(ZERO);
         token("switch");
         builder.space();
         token("(");
@@ -1874,7 +1875,8 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         builder.close();
         builder.forcedBreak();
         builder.blankLineWanted(BlankLineWanted.NO);
-        token("}", plusFour);
+        token("}", plusTwo);
+        builder.close();
     }
 
     @Override

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -58,4 +58,17 @@ class ExpressionSwitch {
           case 2 -> throw new IllegalArgumentException();
           default -> throw new IllegalStateException();};
   }
+
+
+    public void testWithComments(int y) {
+        int x;
+        x = switch (y) {
+            case 1 -> 1;
+            // after case 1
+            case 2 -> throw new IllegalArgumentException();
+            // after case 2
+            default -> throw new IllegalStateException();
+            // after default case
+        };
+    }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.input
@@ -63,12 +63,15 @@ class ExpressionSwitch {
     public void testWithComments(int y) {
         int x;
         x = switch (y) {
-            case 1 -> 1;
-            // after case 1
-            case 2 -> throw new IllegalArgumentException();
-            // after case 2
-            default -> throw new IllegalStateException();
-            // after default case
-        };
+    case 1 ->
+1;
+// after case 1
+    case 2 ->
+throw new IllegalArgumentException();
+// after case 2
+    default ->
+throw new IllegalStateException();
+// after default case
+};
     }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/ExpressionSwitch.output
@@ -65,4 +65,16 @@ class ExpressionSwitch {
             default -> throw new IllegalStateException();
         };
     }
+
+    public void testWithComments(int y) {
+        int x;
+        x = switch (y) {
+            case 1 -> 1;
+            // after case 1
+            case 2 -> throw new IllegalArgumentException();
+            // after case 2
+            default -> throw new IllegalStateException();
+            // after default case
+        };
+    }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Fixes parsing of switch expressions that have a comment before the closing "}". (internal example [here](https://pl.ntr/2x3) with the corresponding failure [here](https://pl.ntr/2x4)). Internal discussion [here](https://pl.ntr/2x5)
==COMMIT_MSG==
Fix comments after default switch case expressions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

