### PR TITLE
Fix latest Intellij incompatibility

### DIFF
--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/Notifications.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/Notifications.java
@@ -16,9 +16,6 @@
 
 package com.palantir.javaformat.intellij;
 
-import com.intellij.formatting.service.FormattingNotificationService;
-import com.intellij.openapi.project.Project;
-
 class Notifications {
 
     static final String GENERIC_ERROR_NOTIFICATION_GROUP = "palantir-java-format error";
@@ -27,13 +24,5 @@ class Notifications {
 
     static String parsingErrorMessage(String filename) {
         return "palantir-java-format failed. Does " + filename + " have syntax errors?";
-    }
-
-    static void displayParsingErrorNotification(Project project, String filename) {
-        FormattingNotificationService.getInstance(project)
-                .reportError(
-                        Notifications.PARSING_ERROR_NOTIFICATION_GROUP,
-                        Notifications.PARSING_ERROR_TITLE,
-                        Notifications.parsingErrorMessage(filename));
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
<img width="1064" height="178" alt="Screenshot 2025-10-06 at 10 33 31 AM" src="https://github.com/user-attachments/assets/745609ed-7c76-4195-a728-dd2ba689cf8c" />

## After this PR
Remove unused method that is also causing incompatibility with Intellij version: 2025.3 eap (253.22441.33)

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix latest Intellij incompatibility
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->


