### PR TITLE
feature: Allow setting 'skip reflowing long strings' in IntelliJ plugin

### DIFF
--- a/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
+++ b/gradle-palantir-java-format/src/main/groovy/com/palantir/javaformat/gradle/PalantirJavaFormatPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.javaformat.gradle;
 
 import com.palantir.javaformat.bootstrap.NativeImageFormatterService;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
@@ -84,7 +85,7 @@ public abstract class PalantirJavaFormatPlugin implements Plugin<Project> {
                 FormatDiff.formatDiff(
                         getProject().getProjectDir().toPath(),
                         new NativeImageFormatterService(
-                                getNativeImage().get().getAsFile().toPath()));
+                                getNativeImage().get().getAsFile().toPath(), JavaFormatterOptions.defaultOptions()));
             } else {
                 log.info("Using the Java-based formatter");
                 JavaFormatExtension extension =

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/FormatDiffTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/FormatDiffTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.bootstrap.NativeImageFormatterService;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -104,11 +105,12 @@ class FormatDiffTest {
     }
 
     private static Stream<FormatterService> getFormatters() throws IOException {
+        JavaFormatterOptions options = JavaFormatterOptions.builder().build();
         return Stream.of(
                 new BootstrappingFormatterService(
-                        javaBinPath(), Runtime.version().feature(), getClasspath()),
+                        javaBinPath(), Runtime.version().feature(), getClasspath(), options),
                 new NativeImageFormatterService(
-                        Path.of(Files.readString(NATIVE_IMAGE_FILE.toPath()).trim())));
+                        Path.of(Files.readString(NATIVE_IMAGE_FILE.toPath()).trim()), options));
     }
 
     private static List<Path> getClasspath() throws IOException {

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/FormatterProvider.java
@@ -33,6 +33,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.palantir.javaformat.bootstrap.BootstrappingFormatterService;
 import com.palantir.javaformat.bootstrap.NativeImageFormatterService;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
@@ -73,14 +74,18 @@ final class FormatterProvider {
                 getSdkVersion(project),
                 settings.getImplementationClassPath(),
                 settings.getNativeImageClassPath(),
-                settings.injectedVersionIsOutdated()));
+                settings.injectedVersionIsOutdated(),
+                settings.isSkipReflowingLongStrings()));
     }
 
     @SuppressWarnings("for-rollout:Slf4jLogsafeArgs")
     private static Optional<FormatterService> createFormatter(FormatterCacheKey cacheKey) {
+        JavaFormatterOptions options = JavaFormatterOptions.builder()
+                .skipReflowingLongStrings(cacheKey.skipReflowingLongStrings)
+                .build();
         if (cacheKey.nativeImageClassPath.isPresent()) {
             log.info("Using the native formatter with classpath: {}", cacheKey.nativeImageClassPath.get());
-            return Optional.of(new NativeImageFormatterService(Path.of(cacheKey.nativeImageClassPath.get())));
+            return Optional.of(new NativeImageFormatterService(Path.of(cacheKey.nativeImageClassPath.get()), options));
         }
         if (cacheKey.jdkMajorVersion.isEmpty()) {
             return Optional.empty();
@@ -96,7 +101,8 @@ final class FormatterProvider {
                 jdkMajorVersion, ApplicationInfo.getInstance().getBuild())) {
             Path jdkPath = getJdkPath(cacheKey.project);
             log.info("Using bootstrapping formatter with jdk version {} and path: {}", jdkMajorVersion, jdkPath);
-            return Optional.of(new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath));
+            return Optional.of(
+                    new BootstrappingFormatterService(jdkPath, jdkMajorVersion, implementationClasspath, options));
         }
 
         // Use "in-process" formatter service
@@ -225,18 +231,21 @@ final class FormatterProvider {
         private final Optional<List<URI>> implementationClassPath;
         private final Optional<URI> nativeImageClassPath;
         private final boolean useBundledImplementation;
+        private final boolean skipReflowingLongStrings;
 
         FormatterCacheKey(
                 Project project,
                 OptionalInt jdkMajorVersion,
                 Optional<List<URI>> implementationClassPath,
                 Optional<URI> nativeImageClassPath,
-                boolean useBundledImplementation) {
+                boolean useBundledImplementation,
+                boolean skipReflowingLongStrings) {
             this.project = project;
             this.jdkMajorVersion = jdkMajorVersion;
             this.implementationClassPath = implementationClassPath;
             this.nativeImageClassPath = nativeImageClassPath;
             this.useBundledImplementation = useBundledImplementation;
+            this.skipReflowingLongStrings = skipReflowingLongStrings;
         }
 
         @Override
@@ -250,6 +259,7 @@ final class FormatterProvider {
             FormatterCacheKey that = (FormatterCacheKey) o;
             return Objects.equals(jdkMajorVersion, that.jdkMajorVersion)
                     && useBundledImplementation == that.useBundledImplementation
+                    && skipReflowingLongStrings == that.skipReflowingLongStrings
                     && Objects.equals(project, that.project)
                     && Objects.equals(implementationClassPath, that.implementationClassPath)
                     && Objects.equals(nativeImageClassPath, that.nativeImageClassPath);
@@ -258,7 +268,12 @@ final class FormatterProvider {
         @Override
         public int hashCode() {
             return Objects.hash(
-                    project, jdkMajorVersion, implementationClassPath, nativeImageClassPath, useBundledImplementation);
+                    project,
+                    jdkMajorVersion,
+                    implementationClassPath,
+                    nativeImageClassPath,
+                    useBundledImplementation,
+                    skipReflowingLongStrings);
         }
     }
 }

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.form
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.form
@@ -21,7 +21,7 @@
           <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Skip reflowing long strings"/>
+          <text value="Skip reflowing long strings (Java 15+)"/>
         </properties>
       </component>
       <component id="c93e1" class="javax.swing.JLabel">

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.form
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.palantir.javaformat.intellij.PalantirJavaFormatConfigurable">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -16,14 +16,17 @@
           <text value="Enable palantir-java-format"/>
         </properties>
       </component>
-      <vspacer id="19e83">
+      <component id="skipReflow" class="javax.swing.JCheckBox" binding="skipReflowingLongStrings" default-binding="true">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
-      </vspacer>
+        <properties>
+          <text value="Skip reflowing long strings"/>
+        </properties>
+      </component>
       <component id="c93e1" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Code style"/>
@@ -31,29 +34,13 @@
       </component>
       <component id="31761" class="javax.swing.JComboBox" binding="styleComboBox" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
-      <component id="d2ce8" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Implementation version"/>
-        </properties>
-      </component>
-      <component id="f9300" class="javax.swing.JLabel" binding="formatterVersion">
-        <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="0" fill="1" indent="1" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="what version are we running with?"/>
-        </properties>
-      </component>
       <component id="6e9b7" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Plugin version"/>
@@ -61,15 +48,31 @@
       </component>
       <component id="ba751" class="javax.swing.JLabel" binding="pluginVersion">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="plugin version"/>
         </properties>
       </component>
-      <component id="ce92" class="javax.swing.JLabel">
+      <component id="d2ce8" class="javax.swing.JLabel">
         <constraints>
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Implementation version"/>
+        </properties>
+      </component>
+      <component id="f9300" class="javax.swing.JLabel" binding="formatterVersion">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="0" fill="1" indent="1" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="what version are we running with?"/>
+        </properties>
+      </component>
+      <component id="ce92" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Formatter type"/>
@@ -77,12 +80,17 @@
       </component>
       <component id="1ad4" class="javax.swing.JLabel" binding="isUsingNativeImage">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="any notes"/>
         </properties>
       </component>
+      <vspacer id="19e83">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatConfigurable.java
@@ -36,6 +36,7 @@ class PalantirJavaFormatConfigurable extends BaseConfigurable implements Searcha
     private final Project project;
     private JPanel panel;
     private JCheckBox enable;
+    private JCheckBox skipReflowingLongStrings;
 
     @SuppressWarnings("for-rollout:RawTypes")
     private JComboBox styleComboBox;
@@ -84,6 +85,7 @@ class PalantirJavaFormatConfigurable extends BaseConfigurable implements Searcha
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         settings.setEnabled(enable.isSelected() ? EnabledState.ENABLED : getDisabledState());
         settings.setStyle(((UiFormatterStyle) styleComboBox.getSelectedItem()).convert());
+        settings.setSkipReflowingLongStrings(skipReflowingLongStrings.isSelected());
     }
 
     private EnabledState getDisabledState() {
@@ -98,6 +100,7 @@ class PalantirJavaFormatConfigurable extends BaseConfigurable implements Searcha
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         enable.setSelected(settings.isEnabled());
         styleComboBox.setSelectedItem(UiFormatterStyle.convert(settings.getStyle()));
+        skipReflowingLongStrings.setSelected(settings.isSkipReflowingLongStrings());
         pluginVersion.setText(settings.getImplementationVersion().orElse("unknown"));
         formatterVersion.setText(getFormatterVersionText(settings));
         isUsingNativeImage.setText(isUsingNativeImage(settings));
@@ -107,7 +110,8 @@ class PalantirJavaFormatConfigurable extends BaseConfigurable implements Searcha
     public boolean isModified() {
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         return enable.isSelected() != settings.isEnabled()
-                || !styleComboBox.getSelectedItem().equals(UiFormatterStyle.convert(settings.getStyle()));
+                || !styleComboBox.getSelectedItem().equals(UiFormatterStyle.convert(settings.getStyle()))
+                || skipReflowingLongStrings.isSelected() != settings.isSkipReflowingLongStrings();
     }
 
     @Override

--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettings.java
@@ -82,6 +82,14 @@ public class PalantirJavaFormatSettings implements PersistentStateComponent<Pala
         state.style = style;
     }
 
+    boolean isSkipReflowingLongStrings() {
+        return state.skipReflowingLongStrings;
+    }
+
+    void setSkipReflowingLongStrings(boolean skipReflowingLongStrings) {
+        state.skipReflowingLongStrings = skipReflowingLongStrings;
+    }
+
     /**
      * The paths to jars that provide an alternative implementation of the formatter. If set, this implementation will
      * be used instead of the bundled version.
@@ -147,6 +155,7 @@ public class PalantirJavaFormatSettings implements PersistentStateComponent<Pala
         private Optional<URI> nativeImageClassPath = Optional.empty();
 
         public JavaFormatterOptions.Style style = JavaFormatterOptions.Style.PALANTIR;
+        public boolean skipReflowingLongStrings = false;
 
         public void setImplementationClassPath(@Nullable List<String> value) {
             implementationClassPath = Optional.ofNullable(value)

--- a/idea-plugin/src/test/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingServiceTest.java
+++ b/idea-plugin/src/test/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingServiceTest.java
@@ -97,6 +97,15 @@ public class PalantirJavaFormatFormattingServiceTest {
         assertThat(delegatingFormatter.wasInvoked()).isTrue();
     }
 
+    @Test
+    public void skipReflowingLongStringsSettingPersists() throws Exception {
+        settings.setSkipReflowingLongStrings(true);
+        assertThat(settings.isSkipReflowingLongStrings()).isTrue();
+
+        settings.setSkipReflowingLongStrings(false);
+        assertThat(settings.isSkipReflowingLongStrings()).isFalse();
+    }
+
     protected Project getProject() {
         return fixture.getProject();
     }

--- a/idea-plugin/src/test/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettingsTest.java
+++ b/idea-plugin/src/test/java/com/palantir/javaformat/intellij/PalantirJavaFormatSettingsTest.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.intellij;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.javaformat.intellij.PalantirJavaFormatSettings.State;
+import org.junit.jupiter.api.Test;
+
+public final class PalantirJavaFormatSettingsTest {
+
+    @Test
+    void skipReflowingLongStrings_defaultIsFalse() {
+        State state = new State();
+        assertThat(state.skipReflowingLongStrings).isFalse();
+    }
+
+    @Test
+    void skipReflowingLongStrings_canBeSetToTrue() {
+        State state = new State();
+        state.skipReflowingLongStrings = true;
+        assertThat(state.skipReflowingLongStrings).isTrue();
+    }
+
+    @Test
+    void skipReflowingLongStrings_canBeSetToFalse() {
+        State state = new State();
+        state.skipReflowingLongStrings = true;
+        state.skipReflowingLongStrings = false;
+        assertThat(state.skipReflowingLongStrings).isFalse();
+    }
+
+    @Test
+    void skipReflowingLongStrings_persistsAcrossStateInstances() {
+        State state1 = new State();
+        state1.skipReflowingLongStrings = true;
+
+        State state2 = new State();
+        state2.skipReflowingLongStrings = state1.skipReflowingLongStrings;
+
+        assertThat(state2.skipReflowingLongStrings).isTrue();
+    }
+}

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.palantir.javaformat.java.FormatterException;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import com.palantir.javaformat.java.Replacement;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,11 +45,17 @@ public final class BootstrappingFormatterService implements FormatterService {
     private final Path jdkPath;
     private final Integer jdkMajorVersion;
     private final List<Path> implementationClassPath;
+    private final JavaFormatterOptions formatterOptions;
 
-    public BootstrappingFormatterService(Path jdkPath, Integer jdkMajorVersion, List<Path> implementationClassPath) {
+    public BootstrappingFormatterService(
+            Path jdkPath,
+            Integer jdkMajorVersion,
+            List<Path> implementationClassPath,
+            JavaFormatterOptions formatterOptions) {
         this.jdkPath = jdkPath;
         this.jdkMajorVersion = jdkMajorVersion;
         this.implementationClassPath = implementationClassPath;
+        this.formatterOptions = formatterOptions;
     }
 
     @Override
@@ -85,6 +92,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .withJvmArgsForVersion(jdkMajorVersion)
                 .implementationClasspath(implementationClassPath)
                 .outputReplacements(true)
+                .skipReflowingLongStrings(formatterOptions.skipReflowingLongStrings())
                 .characterRanges(ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
                 .build();
 
@@ -103,6 +111,7 @@ public final class BootstrappingFormatterService implements FormatterService {
                 .withJvmArgsForVersion(jdkMajorVersion)
                 .implementationClasspath(implementationClassPath)
                 .outputReplacements(false)
+                .skipReflowingLongStrings(formatterOptions.skipReflowingLongStrings())
                 .build();
         return FormatterCommandRunner.runWithStdin(command.toArgs(), input, Optional.ofNullable(jdkPath.getParent()))
                 .orElse(input);
@@ -113,6 +122,8 @@ public final class BootstrappingFormatterService implements FormatterService {
         List<String> characterRanges();
 
         boolean outputReplacements();
+
+        boolean skipReflowingLongStrings();
 
         Path jdkPath();
 
@@ -136,6 +147,9 @@ public final class BootstrappingFormatterService implements FormatterService {
             }
             if (outputReplacements()) {
                 args.add("--output-replacements");
+            }
+            if (skipReflowingLongStrings()) {
+                args.add("--skip-reflowing-long-strings");
             }
 
             return args

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/BootstrappingFormatterService.java
@@ -47,6 +47,21 @@ public final class BootstrappingFormatterService implements FormatterService {
     private final List<Path> implementationClassPath;
     private final JavaFormatterOptions formatterOptions;
 
+    /**
+     * Creates a BootstrappingFormatterService with default formatter options.
+     * Provided for backward compatibility with code that does not pass JavaFormatterOptions.
+     *
+     * @deprecated Use {@link #BootstrappingFormatterService(Path, Integer, List, JavaFormatterOptions)} instead
+     */
+    @Deprecated
+    public BootstrappingFormatterService(Path jdkPath, Integer jdkMajorVersion, List<Path> implementationClassPath) {
+        this(
+                jdkPath,
+                jdkMajorVersion,
+                implementationClassPath,
+                JavaFormatterOptions.builder().build());
+    }
+
     public BootstrappingFormatterService(
             Path jdkPath,
             Integer jdkMajorVersion,

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
@@ -41,6 +41,17 @@ public class NativeImageFormatterService implements FormatterService {
     private final Path nativeImagePath;
     private final JavaFormatterOptions formatterOptions;
 
+    /**
+     * Creates a NativeImageFormatterService with default formatter options.
+     * Provided for backward compatibility with code that does not pass JavaFormatterOptions.
+     *
+     * @deprecated Use {@link #NativeImageFormatterService(Path, JavaFormatterOptions)} instead
+     */
+    @Deprecated
+    public NativeImageFormatterService(Path nativeImagePath) {
+        this(nativeImagePath, JavaFormatterOptions.builder().build());
+    }
+
     public NativeImageFormatterService(Path nativeImagePath, JavaFormatterOptions formatterOptions) {
         this.nativeImagePath = nativeImagePath;
         this.formatterOptions = formatterOptions;

--- a/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
+++ b/palantir-java-format-jdk-bootstrap/src/main/java/com/palantir/javaformat/bootstrap/NativeImageFormatterService.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import com.palantir.javaformat.java.Replacement;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -38,9 +39,11 @@ public class NativeImageFormatterService implements FormatterService {
     private static final ObjectMapper MAPPER =
             JsonMapper.builder().addModule(new GuavaModule()).build();
     private final Path nativeImagePath;
+    private final JavaFormatterOptions formatterOptions;
 
-    public NativeImageFormatterService(Path nativeImagePath) {
+    public NativeImageFormatterService(Path nativeImagePath, JavaFormatterOptions formatterOptions) {
         this.nativeImagePath = nativeImagePath;
+        this.formatterOptions = formatterOptions;
     }
 
     @Override
@@ -50,6 +53,7 @@ public class NativeImageFormatterService implements FormatterService {
             FormatterNativeImageArgs command = FormatterNativeImageArgs.builder()
                     .nativeImagePath(nativeImagePath)
                     .outputReplacements(true)
+                    .skipReflowingLongStrings(formatterOptions.skipReflowingLongStrings())
                     .characterRanges(
                             ranges.stream().map(RangeUtils::toStringRange).collect(Collectors.toList()))
                     .build();
@@ -88,6 +92,7 @@ public class NativeImageFormatterService implements FormatterService {
         FormatterNativeImageArgs command = FormatterNativeImageArgs.builder()
                 .nativeImagePath(nativeImagePath)
                 .outputReplacements(false)
+                .skipReflowingLongStrings(formatterOptions.skipReflowingLongStrings())
                 .build();
         return FormatterCommandRunner.runWithStdin(
                         command.toArgs(), input, Optional.ofNullable(nativeImagePath.getParent()))
@@ -101,6 +106,8 @@ public class NativeImageFormatterService implements FormatterService {
 
         boolean outputReplacements();
 
+        boolean skipReflowingLongStrings();
+
         Path nativeImagePath();
 
         default List<String> toArgs() {
@@ -112,6 +119,9 @@ public class NativeImageFormatterService implements FormatterService {
             }
             if (outputReplacements()) {
                 args.add("--output-replacements");
+            }
+            if (skipReflowingLongStrings()) {
+                args.add("--skip-reflowing-long-strings");
             }
 
             return args

--- a/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/FormatterServicesTest.java
+++ b/palantir-java-format-jdk-bootstrap/src/test/java/com/palantir/javaformat/bootstrap/FormatterServicesTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Range;
 import com.palantir.javaformat.Utils;
 import com.palantir.javaformat.java.FormatterException;
 import com.palantir.javaformat.java.FormatterService;
+import com.palantir.javaformat.java.JavaFormatterOptions;
 import com.palantir.javaformat.java.Replacement;
 import java.net.URI;
 import java.nio.file.Files;
@@ -98,11 +99,14 @@ final class FormatterServicesTest {
     }
 
     private static Stream<FormatterService> getFormatters() {
+        JavaFormatterOptions options =
+                JavaFormatterOptions.builder().skipReflowingLongStrings(false).build();
+
         return Stream.of(
                 new BootstrappingFormatterService(
-                        javaBinPath(), Runtime.version().feature(), getClasspath()),
+                        javaBinPath(), Runtime.version().feature(), getClasspath(), options),
                 new NativeImageFormatterService(
-                        Path.of(System.getenv("NATIVE_IMAGE_CLASSPATH").toString())));
+                        Path.of(System.getenv("NATIVE_IMAGE_CLASSPATH").toString()), options));
     }
 
     private String getTestResourceContent(String resourceName) {

--- a/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
+++ b/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
@@ -59,9 +59,12 @@ public final class JavaFormatterOptions {
 
     private final boolean formatJavadoc;
 
-    private JavaFormatterOptions(Style style, boolean formatJavadoc) {
+    private final boolean skipReflowingLongStrings;
+
+    private JavaFormatterOptions(Style style, boolean formatJavadoc, boolean skipReflowingLongStrings) {
         this.style = style;
         this.formatJavadoc = formatJavadoc;
+        this.skipReflowingLongStrings = skipReflowingLongStrings;
     }
 
     /** Returns the multiplier for the unit of indent. */
@@ -75,6 +78,10 @@ public final class JavaFormatterOptions {
 
     public boolean formatJavadoc() {
         return formatJavadoc;
+    }
+
+    public boolean skipReflowingLongStrings() {
+        return skipReflowingLongStrings;
     }
 
     /** Returns the code style. */
@@ -99,6 +106,8 @@ public final class JavaFormatterOptions {
 
         private boolean formatJavadoc = false;
 
+        private boolean skipReflowingLongStrings = false;
+
         private Builder() {}
 
         public Builder style(Style style) {
@@ -111,8 +120,13 @@ public final class JavaFormatterOptions {
             return this;
         }
 
+        public Builder skipReflowingLongStrings(boolean skipReflowingLongStrings) {
+            this.skipReflowingLongStrings = skipReflowingLongStrings;
+            return this;
+        }
+
         public JavaFormatterOptions build() {
-            return new JavaFormatterOptions(style, formatJavadoc);
+            return new JavaFormatterOptions(style, formatJavadoc, skipReflowingLongStrings);
         }
     }
 }


### PR DESCRIPTION
## Before this PR
The core formatter supports a 'skip reflowing long strings' option but this couldn't be selected in the IntelliJ plugin settings.

## After this PR
The plugin settings UI now has an option to skip reflowing long strings (which is respected by formatters).

<img width="979" height="398" alt="image" src="https://github.com/user-attachments/assets/a6312e40-3fe1-4d52-b72c-e77da8fcd33e" />

## Possible downsides?
* Java 15 and above only - the setting is ignored for earlier JVMs due to the way the in-process formatter is instantiated.

## Related Issues
Address Issue https://github.com/palantir/palantir-java-format/issues/1452
