### PR TITLE
improvement: Publish executable shadowJar for formatter with CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.6.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.81.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.24.0'
+        classpath 'com.github.johnrengelman:shadow:8.1.1'
         classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
         classpath 'org.revapi:gradle-revapi:1.8.0'
     }

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'application'
 apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 mainClassName = 'com.palantir.javaformat.java.Main'
 
@@ -64,4 +65,20 @@ tasks.named("test") {
 
 javaVersion {
     target = 21
+}
+
+shadowJar {
+    manifest {
+        attributes 'Main-Class': 'com.palantir.javaformat.java.Main'
+    }
+}
+
+publishing {
+    publications {
+        maven {
+            artifact(shadowJar) {
+                classifier = 'executable'
+            }
+        }
+    }
 }


### PR DESCRIPTION
Configure the palantir-java-format module to publish the shadowJar (fat JAR with all dependencies) as an additional artifact with 'executable' classifier. This enables distributing a self-contained formatter jar alongside the standard library artifacts.

## Before this PR
The palantir-java-format Jar artifacts published from CI are not executable, making it hard to use the formatter as a CLI

## After this PR
* A shadow Jar is built alongside the default formatter Jar
* The shadow Jar is additionally published to Maven with the 'executable' classifier

## Possible downsides?
None I can think of

