### PR TITLE
get rid of truth

### DIFF
--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'
 
     testImplementation 'com.google.guava:guava-testlib'
-    testImplementation 'com.google.truth:truth'
     testImplementation 'com.google.testing.compile:compile-testing'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter-migrationsupport'

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/CommandLineOptionsParserTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/CommandLineOptionsParserTest.java
@@ -14,9 +14,8 @@
 
 package com.palantir.javaformat.java;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.Range;

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/TypeNameClassifierTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/TypeNameClassifierTest.java
@@ -14,9 +14,8 @@
 
 package com.palantir.javaformat.java;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static com.palantir.javaformat.java.TypeNameClassifier.JavaCaseFormat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
 import java.util.Optional;

--- a/versions.lock
+++ b/versions.lock
@@ -34,11 +34,11 @@ com.google.auto.service:auto-service-annotations:1.1.1 (1 constraints: 9c0f6a86)
 
 com.google.code.findbugs:jsr305:3.0.2 (2 constraints: 4112851c)
 
-com.google.errorprone:error_prone_annotations:2.36.0 (4 constraints: 4b27bf7b)
+com.google.errorprone:error_prone_annotations:2.36.0 (4 constraints: 1c277a54)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.4.8-jre (9 constraints: 5ea13c2f)
+com.google.guava:guava:33.4.8-jre (9 constraints: 5da1982e)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
@@ -132,13 +132,13 @@ cglib:cglib-nodep:3.2.2 (1 constraints: 490ded24)
 
 com.google.auto.value:auto-value:1.10 (1 constraints: e711f8e8)
 
-com.google.auto.value:auto-value-annotations:1.10.4 (1 constraints: 8e0aa3c3)
+com.google.auto.value:auto-value-annotations:1.8.1 (1 constraints: 620a29b9)
 
 com.google.guava:guava-testlib:27.0.1-jre (1 constraints: aa067c53)
 
 com.google.testing.compile:compile-testing:0.21.0 (1 constraints: 35052a3b)
 
-com.google.truth:truth:1.4.1 (2 constraints: 1f178e31)
+com.google.truth:truth:1.1.3 (1 constraints: 18120efb)
 
 com.netflix.nebula:nebula-test:10.0.0 (1 constraints: 3305273b)
 
@@ -152,7 +152,7 @@ org.apiguardian:apiguardian-api:1.1.2 (10 constraints: 8fb0f648)
 
 org.assertj:assertj-core:3.25.3 (1 constraints: 3f054b3b)
 
-org.checkerframework:checker-qual:3.42.0 (3 constraints: 1c2a3b96)
+org.checkerframework:checker-qual:3.26.0 (3 constraints: 1a2a3296)
 
 org.codehaus.groovy:groovy:3.0.6 (2 constraints: 1e1b476d)
 
@@ -194,7 +194,7 @@ org.openjdk.jmh:jmh-generator-reflection:1.37 (2 constraints: 491e3064)
 
 org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
 
-org.ow2.asm:asm:9.6 (2 constraints: f417596a)
+org.ow2.asm:asm:9.1 (2 constraints: ef178c69)
 
 org.spockframework:spock-core:2.0-M4-groovy-3.0 (2 constraints: e822d65a)
 

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,6 @@ com.google.errorprone:error_prone_annotations = 2.11.0
 com.google.guava:guava = 33.0.0-jre
 com.google.guava:guava-testlib = 27.0.1-jre
 com.google.testing.compile:compile-testing = 0.21.0
-com.google.truth:truth = 1.4.1
 com.palantir.sls.versions:sls-versions = 1.5.0
 com.netflix.nebula:nebula-test = 10.0.0
 junit:junit = 4.13.2


### PR DESCRIPTION
## Before this PR
This repo has been failing Upgrade Dependencies excavator for almost 2 years (since Feb 29, 2024). https://github.com/palantir/palantir-java-format/pulls?q=is%3Apr+%22Excavator%3A+Upgrade+dependencies%22+ .  It's gone through a series of PRs that it opened and closed in that time.  This is the current one - https://github.com/palantir/palantir-java-format/pull/1473

The reason (I think) is that it uses a library called com.google.truth:truth for an assertThat and there are (possibly) multiple versions of it.  Why we use this library _and_ also use assertj, I don't know.  I've removed uses of truth to hopefully unblock other things.

And yes, I did get dark amusement out of the subject of this PR.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

