### PR TITLE
Spotless excludes  formatting of `**/build/*` files

### DIFF
--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -51,6 +51,7 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
 
     @Override
     public void execute(JavaExtension java) {
+        java.targetExclude("**/build/**/*");
         // This is configuration cache safe as happening afterEvaluate
         java.addStep(spotlessJavaFormatStep());
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We were formatting [all javaSource files](https://github.com/diffplug/spotless/blob/main/plugin-gradle/src/main/java/com/diffplug/gradle/spotless/JvmLang.java#L38), even if the files are generated  (most of the times they end up being in the build/ directory and not committed).

## After this PR
Perf improvement for internal repo from https://pl.ntr/2Dq (4m 30s) -> https://pl.ntr/2Do (3m 56.530s)
==COMMIT_MSG==
Spotless excludes  formatting of `**/build/*` files
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

