### PR TITLE
Exclude generated directories for formatting

### DIFF
--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -51,7 +51,10 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
 
     @Override
     public void execute(JavaExtension java) {
+        // Exclude build directories at root and in subprojects
         java.targetExclude("**/build/**/*");
+        // Re-include any build directories that are inside src directories
+        java.target("**/src/**/build/**/*");
         // This is configuration cache safe as happening afterEvaluate
         java.addStep(spotlessJavaFormatStep());
     }

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -51,10 +51,11 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
 
     @Override
     public void execute(JavaExtension java) {
-        // Exclude build directories at root and in subprojects
-        java.targetExclude("**/build/**/*");
-        // Re-include any build directories that are inside src directories
-        java.target("**/src/**/build/**/*");
+        // Exclude generated source directories
+        java.targetExclude("**/build/generated*/**");
+        java.targetExclude("**/src/generated*/**");
+        java.targetExclude("**/generated_*src/**");
+        java.targetExclude("**/generated_*Src/**");
         // This is configuration cache safe as happening afterEvaluate
         java.addStep(spotlessJavaFormatStep());
     }

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -52,6 +52,8 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
     @Override
     public void execute(JavaExtension java) {
         // Exclude generated source directories
+        // Note: We cannot simply exclude **/build/**/* because some repos might contain a build directory
+        // within the src sourceset that should be formatted.
         java.targetExclude("**/build/generated*/**");
         java.targetExclude("**/src/generated*/**");
         java.targetExclude("**/generated_*src/**");


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
FLUP for https://github.com/palantir/palantir-java-format/pull/1531
Some source directories might have `build` in the directory structure; this regex  would ignore these files. 


## After this PR
Exclude generated directories - same logic as in error-prone [here](https://github.com/palantir/suppressible-error-prone/blob/611ff7acd4462afd6aa0464ea6925c0190bd556f/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePlugin.java#L217-L224). Internal thread [here](https://pl.ntr/2Eh).

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Exclude generated directories
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

