### PR TITLE
Fix parsing of unnamed patterns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects {
 
 javaVersions {
     libraryTarget = 17
-    runtime = 21
+    runtime = 23
 }
 
 jdks {

--- a/palantir-java-format-spi/build.gradle
+++ b/palantir-java-format-spi/build.gradle
@@ -18,5 +18,5 @@ tasks.withType(JavaCompile).named('compileJava') {
 }
 
 javaVersion {
-    target = 21
+    target = 23
 }

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -41,6 +41,16 @@ moduleJvmArgs {
             'jdk.compiler/com.sun.tools.javac.api')
 }
 
+applicationDefaultJvmArgs = [
+        '--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
+]
+
 tasks.withType(JavaCompile).named('compileJava') {
     // By setting the source and target compatibility to 11, while still using a higher level
     // JDK for compilation, we can compile against the AST classes we need to support >11 source

--- a/palantir-java-format/build.gradle
+++ b/palantir-java-format/build.gradle
@@ -62,5 +62,5 @@ tasks.named("test") {
 }
 
 javaVersion {
-    target = 21
+    target = 23
 }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavacTokens.java
@@ -27,7 +27,9 @@ import com.sun.tools.javac.parser.Tokens.Token;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import com.sun.tools.javac.parser.UnicodeReader;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** A wrapper around javac's lexer. */
 class JavacTokens {
@@ -176,6 +178,12 @@ class JavacTokens {
             checkArgument(
                     0 <= index && index < (endPos - pos), "Expected %s in the range [0, %s)", index, endPos - pos);
             return pos + index;
+        }
+
+        @Override
+        @Nullable
+        public DiagnosticPosition getPos() {
+            return null;
         }
 
         @Override

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/RemoveUnusedImports.java
@@ -226,7 +226,12 @@ public class RemoveUnusedImports {
             Set<String> usedNames,
             Multimap<String, Range<Integer>> usedInJavadoc) {
         RangeMap<Integer, String> replacements = TreeRangeMap.create();
-        for (JCImport importTree : unit.getImports()) {
+        for (Object o : unit.getImports()) {
+            if (!(o instanceof JCImport)) {
+                // TODO: In Java >=23, getImports() returns JCImportBase
+                continue;
+            }
+            JCImport importTree = (JCImport) o;
             String simpleName = getSimpleName(importTree);
             if (!isUnused(unit, usedNames, usedInJavadoc, importTree, simpleName)) {
                 continue;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/java21/Java21InputAstVisitor.java
@@ -18,6 +18,7 @@ package com.palantir.javaformat.java.java21;
 
 import com.palantir.javaformat.OpsBuilder;
 import com.palantir.javaformat.java.java14.Java14InputAstVisitor;
+import com.sun.source.tree.AnyPatternTree;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ConstantCaseLabelTree;
 import com.sun.source.tree.DeconstructionPatternTree;
@@ -87,5 +88,11 @@ public class Java21InputAstVisitor extends Java14InputAstVisitor {
         } else {
             visit(name);
         }
+    }
+
+    @Override
+    public Void visitAnyPattern(AnyPatternTree node, Void unused) {
+        token("_");
+        return null;
     }
 }

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FileBasedTests.java
@@ -59,7 +59,8 @@ public final class FileBasedTests {
                             "SwitchUnderscore",
                             "I880",
                             "I1309",
-                            "Unnamed")
+                            "Unnamed",
+                            "UnnamedPattern")
                     .build();
 
     private final Class<?> testClass;

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/UnnamedPattern.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/UnnamedPattern.input
@@ -1,0 +1,19 @@
+class UnnamedPattern {
+    public static void main(String[] args) {
+        var cp = new ColoredPoint(new Point(1, 2), Color.RED);
+
+        // The colour doesn't matter, so use an unnamed pattern
+        // (as opposed to the unnamed type pattern `var _`).
+        if (cp instanceof ColoredPoint(Point(int x, int y), _)) {
+            System.out.println(x + "," + y);
+        }
+
+        if (cp instanceof ColoredPoint(_, var c)) {
+            System.out.println(c);
+        }
+    }
+}
+
+record Point(int x, int y) { }
+enum Color { RED, GREEN, BLUE }
+record ColoredPoint(Point p, Color c) { }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/UnnamedPattern.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/UnnamedPattern.output
@@ -1,0 +1,25 @@
+class UnnamedPattern {
+    public static void main(String[] args) {
+        var cp = new ColoredPoint(new Point(1, 2), Color.RED);
+
+        // The colour doesn't matter, so use an unnamed pattern
+        // (as opposed to the unnamed type pattern `var _`).
+        if (cp instanceof ColoredPoint(Point(int x, int y), _)) {
+            System.out.println(x + "," + y);
+        }
+
+        if (cp instanceof ColoredPoint(_, var c)) {
+            System.out.println(c);
+        }
+    }
+}
+
+record Point(int x, int y) {}
+
+enum Color {
+    RED,
+    GREEN,
+    BLUE
+}
+
+record ColoredPoint(Point p, Color c) {}


### PR DESCRIPTION
## Before this PR

I came across FormatException of the form `error: expected token: '_'; generated ) instead` when using unnamed patterns, like the following (from the JEP):

```
class UnnamedPattern {
    public static void main(String[] args) {
        var cp = new ColoredPoint(new Point(1, 2), Color.RED);

        // The colour doesn't matter, so use an unnamed pattern
        // (as opposed to the unnamed type pattern `var _`).
        if (cp instanceof ColoredPoint(Point(int x, int y), _)) {
            System.out.println(x + "," + y);
        }

        if (cp instanceof ColoredPoint(_, var c)) {
            System.out.println(c);
        }
    }
}

record Point(int x, int y) { }
enum Color { RED, GREEN, BLUE }
record ColoredPoint(Point p, Color c) { }
```

I resolved this by overriding `visitAnyPattern(AnyPatternTree node, Void unused)` in the existing `Java21InputAstVisitor`.

However, `AnyPatternTree` is annotated as a preview feature in Java 21 so I changed Java versions from 21 to 23.

Before changing the version, I tried adding `--enable-preview` but then I got an error message that `--enable-preview` is not compatible with Java 11 source.

I also noticed Java 23 mentioned in the root `build.gradle` so I changed it to 23 rather than 22, 24, 25.

One thing I found in this change was that `getImports()` now returns a `JCImportBase`, so to ensure backwards compatibility I added an `instanceof` check that (and module imports support would need to be implemented in the future).

## After this PR
==COMMIT_MSG==
Fix parsing of unnamed patterns
==COMMIT_MSG==

## Possible downsides?

I'm not sure if changing Java versions from 21 to 23 (runtime in root build.gradle, target in `palantir-java-format-spi/build.gradle` and target in `palantir-java-format/build.gradle`) will have any negative effect? And if another solution should be found to resolve the issue.