### PR TITLE
Do not format precompiled Groovy convention plugins

### DIFF
--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -58,6 +58,10 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
         java.targetExclude("**/src/generated*/**");
         java.targetExclude("**/generated_*src/**");
         java.targetExclude("**/generated_*Src/**");
+        // build/groovy-dsl-plugins contains Java wrapper classes for
+        // https://docs.gradle.org/9.3.1/userguide/implementing_gradle_plugins_convention.html
+        // and don't need to be formatted.
+        java.targetExclude("**/groovy-dsl-plugins/**");
         // This is configuration cache safe as happening afterEvaluate
         java.addStep(spotlessJavaFormatStep());
     }


### PR DESCRIPTION
## Before this PR
In #1568, we tweaked the excludes for generated code to not blanket exclude `build` files. However, an internal repo uses [Convention Plugins](https://docs.gradle.org/9.3.1/userguide/implementing_gradle_plugins_convention.html) which make these Java classes we do not need to format.

Since these live at `build/groovy-dsl-plugins/output`, they do not currently get excluded and we get errors of the forms:

```
Execution failed for task ':spotlessJavaCheck'.
> The following files had format violations:
      build/groovy-dsl-plugins/output/adapter-src/NamwConventionsPlugin.java
          @@ -1,21 +1,29 @@
          -//CHECKSTYLE:OFF
          -import·org.gradle.util.GradleVersion;
          +/*
          +·*·(c)·Copyright·2026·Palantir·Technologies·Inc.·All·rights·reserved.
          +·*/
          +//·CHECKSTYLE:OFF
           import·org.gradle.groovy.scripts.BasicScript;
           import·org.gradle.groovy.scripts.ScriptSource;
           import·org.gradle.groovy.scripts.TextResourceScriptSource;
           import·org.gradle.internal.resource.StringTextResource;
          +import·org.gradle.util.GradleVersion;
          +
           /**
           ·*·Precompiled·name·script·plugin.
           ·**/
           @SuppressWarnings("DefaultPackage")
          -public·class·NameConventionsPlugin·implements·org.gradle.api.Plugin<org.gradle.api.internal.project.ProjectInternal>·{
          +public·class·NameConventionsPlugin
```

## After this PR
==COMMIT_MSG==
Exclude precompiled [Convention Plugins](https://docs.gradle.org/9.3.1/userguide/implementing_gradle_plugins_convention.html) from formatting
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

