### PR TITLE
Use supported macos circleci resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 15.4.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 26.3.0
+    resource_class: m4pro.medium
     environment:
       GRADLE_OPTS: -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs='-Xmx2147483648 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g -XX:+CrashOnOutOfMemoryError


### PR DESCRIPTION
## Before this PR
All our macos builds are failing with ([example](https://app.circleci.com/pipelines/github/palantir/palantir-java-format/5815/workflows/cef3a758-2538-4853-bb51-7693f14c3375/jobs/24305)):

> Job was rejected because resource class macos.m1.medium.gen1, image xcode:15.4.0 is not a valid resource class

It looks like circleci has removed support for these.

## After this PR
Use the latest resource classes from https://circleci.com/docs/guides/execution-managed/using-macos/#supported-xcode-versions

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

