### PR TITLE
 Fix crash when formatting method references 

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/doc/CountWidthUntilBreakVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/doc/CountWidthUntilBreakVisitor.java
@@ -67,15 +67,11 @@ class CountWidthUntilBreakVisitor implements DocVisitor<Float> {
         if (found.isPresent()) {
             return visit(level.getDocs().get(found.getAsInt()));
         }
-        // Otherwise, assert that we encountered a break and move on.
-        if (StartsWithBreakVisitor.INSTANCE.visit(level) != Result.YES) {
-            // Avoid computing expensive level.representation() if we aren't throwing it in an exception.
-            throw new IllegalStateException(String.format(
-                    "Didn't find expected break at the beginning of level.\n%s",
-                    level.representation(State.startingState())));
-        }
-
-        return 0f;
+        // Level starts with tokens directly (e.g. method reference qualifier) — sum doc widths up to the first break.
+        return level.getDocs().stream()
+                .takeWhile(doc -> !(doc instanceof Break))
+                .map(Doc::getWidth)
+                .reduce(0f, Float::sum);
     }
 
     /**

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/A.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/A.input
@@ -80,5 +80,18 @@ class A {
         2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2
             + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2
             + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
+        return StreamEx.of(itemsToCreate)
+                .append(itemsToEdit)
+                .append(itemsToDelete)
+                .distinct()
+                .mapToEntry(item -> getArgsGenerator()
+                        .getNewArgs(
+                                extendedItems.getOrDefault(item, Set.of()),
+                                getOwningResource(
+                                        item,
+                                        getModificationContext()::getRestrictionStatusOrDefault,
+                                        RestrictionStatus::getPackageId,
+                                        getModificationContext())))
+                .toImmutableMap();
   }
 }

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/A.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/A.output
@@ -70,5 +70,18 @@ class A {
         something = 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2
                 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2
                 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
+        return StreamEx.of(itemsToCreate)
+                .append(itemsToEdit)
+                .append(itemsToDelete)
+                .distinct()
+                .mapToEntry(item -> getArgsGenerator()
+                        .getNewArgs(
+                                extendedItems.getOrDefault(item, Set.of()),
+                                getOwningResource(
+                                        item,
+                                        getModificationContext()::getRestrictionStatusOrDefault,
+                                        RestrictionStatus::getPackageId,
+                                        getModificationContext())))
+                .toImmutableMap();
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Internal thread [here](https://pl.ntr/2Al)
Formatting code containing a method reference whose qualifier is a simple method call (e.g. `getModificationContext()::getRestrictionStatusOrDefault`) threw:
```
<File>.java:LINE_UNDEFINED palantir-java-format(java.lang.IllegalStateException) Didn't find expected break at the beginning of level. (...)
  Resolve these lints or suppress with `suppressLintsFor`
```

This happened because `CountWidthUntilBreakVisitor.visitLevel` — which computes how wide a prefix is before its first break — assumed all levels either had a special inlineability hint or started with nested Level objects. A simple method call starts with a `Token`, which matched neither case and fell through to a throw.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
The fallback instead walks the level's docs, summing their widths until the first Break.

==COMMIT_MSG==
 Fix crash when formatting method references 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

