### PR TITLE
specify coding style for Walmart

### DIFF
--- a/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
+++ b/palantir-java-format-spi/src/main/java/com/palantir/javaformat/java/JavaFormatterOptions.java
@@ -36,7 +36,10 @@ public final class JavaFormatterOptions {
         GOOGLE(1, 100),
 
         /** The AOSP-compliant configuration. */
-        AOSP(2, 100);
+        AOSP(2, 100),
+
+        /** The Walmart Java Style configuration. */
+        WALMART(1, 120);
 
         private final int indentationMultiplier;
         private final int maxLineLength;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/ImportOrderer.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/ImportOrderer.java
@@ -171,7 +171,7 @@ public final class ImportOrderer {
         this.text = text;
         this.toks = toks;
         this.lineSeparator = Newlines.guessLineSeparator(text);
-        if (style.equals(Style.GOOGLE) || style.equals(Style.PALANTIR)) {
+        if (style.equals(Style.GOOGLE) || style.equals(Style.PALANTIR) || style.equals(Style.WALMART)) {
             this.importComparator = GOOGLE_IMPORT_COMPARATOR;
             this.shouldInsertBlankLineFn = ImportOrderer::shouldInsertBlankLineGoogle;
         } else if (style.equals(Style.AOSP)) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The palantir-java-format library supports three coding styles: PALANTIR (2-space indent, 120 char line length), GOOGLE (1-space indent multiplier, 100 char line length), and AOSP (2-space indent, 100 char line length). There was no option for teams that prefer Google-style import ordering with a 120 character line length limit.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==
Add WALMART style option that combines Google-style formatting (1-space indent multiplier, Google import ordering) with a 120 character maximum line length. This provides an alternative for teams who prefer the readability of longer lines while maintaining Google's import organization conventions.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

