### PR TITLE
Fix markdown docstring wrapping

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
@@ -113,6 +113,14 @@ public final class JavaCommentsHelper implements CommentsHelper {
     private static final Pattern LINE_COMMENT_MISSING_SPACE_PREFIX =
             Pattern.compile("^(//+)(?!noinspection|\\$NON-NLS-\\d+\\$)[^\\s/]");
 
+    private static String lineCommentPrefix(String line) {
+        int prefixLength = 0;
+        while (prefixLength < line.length() && line.charAt(prefixLength) == '/') {
+            prefixLength++;
+        }
+        return "/".repeat(Math.max(prefixLength, 2));
+    }
+
     private List<String> wrapLineComments(List<String> lines, int column0) {
         List<String> result = new ArrayList<>();
         for (String line : lines) {
@@ -128,11 +136,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
                 continue;
             }
             // Preserve the original slash prefix (e.g. `///` for markdown docstrings) on wrapped lines.
-            int prefixLength = 0;
-            while (prefixLength < line.length() && line.charAt(prefixLength) == '/') {
-                prefixLength++;
-            }
-            String prefix = "/".repeat(Math.max(prefixLength, 2));
+            String prefix = lineCommentPrefix(line);
             while (line.length() + column0 > options.maxLineLength()) {
                 int idx = options.maxLineLength() - column0;
                 // only break on whitespace characters, and ignore the leading `// `

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
@@ -127,17 +127,23 @@ public final class JavaCommentsHelper implements CommentsHelper {
                 result.add(line);
                 continue;
             }
+            // Preserve the original slash prefix (e.g. `///` for markdown docstrings) on wrapped lines.
+            int prefixLength = 0;
+            while (prefixLength < line.length() && line.charAt(prefixLength) == '/') {
+                prefixLength++;
+            }
+            String prefix = "/".repeat(Math.max(prefixLength, 2));
             while (line.length() + column0 > options.maxLineLength()) {
                 int idx = options.maxLineLength() - column0;
                 // only break on whitespace characters, and ignore the leading `// `
-                while (idx >= 2 && !CharMatcher.whitespace().matches(line.charAt(idx))) {
+                while (idx >= prefix.length() && !CharMatcher.whitespace().matches(line.charAt(idx))) {
                     idx--;
                 }
-                if (idx <= 2) {
+                if (idx <= prefix.length()) {
                     break;
                 }
                 result.add(line.substring(0, idx));
-                line = "//" + line.substring(idx);
+                line = prefix + line.substring(idx);
             }
             result.add(line);
         }

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
@@ -118,7 +118,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
         while (prefixLength < line.length() && line.charAt(prefixLength) == '/') {
             prefixLength++;
         }
-        return "/".repeat(Math.max(prefixLength, 2));
+        return "/".repeat(prefixLength);
     }
 
     private List<String> wrapLineComments(List<String> lines, int column0) {

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -432,19 +432,18 @@ public final class FormatterTest {
 
     @Test
     public void wrapMarkdownDocstringComment() throws Exception {
-        assertThat(Formatter.create()
-                        .formatSource("class T {\n"
-                                + "  /// one long incredibly"
-                                + " unbroken sentence moving from topic to topic so that no-one had a"
-                                + " chance to interrupt;\n"
-                                + "  void m() {}\n"
-                                + "}\n"))
-                .isEqualTo("class T {\n"
-                        + "  /// one long incredibly unbroken sentence moving from topic to topic so that"
-                        + " no-one had a chance\n"
-                        + "  /// to interrupt;\n"
-                        + "  void m() {}\n"
-                        + "}\n");
+        String input = "class T {\n"
+                + "  /// one long incredibly unbroken sentence moving from topic to topic so that no-one"
+                + " had a chance to interrupt;\n"
+                + "  void m() {}\n"
+                + "}\n";
+        String expected = "class T {\n"
+                + "  /// one long incredibly unbroken sentence moving from topic to topic so that no-one"
+                + " had a chance\n"
+                + "  /// to interrupt;\n"
+                + "  void m() {}\n"
+                + "}\n";
+        assertThat(Formatter.create().formatSource(input)).isEqualTo(expected);
     }
 
     @Test

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -431,6 +431,23 @@ public final class FormatterTest {
     }
 
     @Test
+    public void wrapMarkdownDocstringComment() throws Exception {
+        assertThat(Formatter.create()
+                        .formatSource("class T {\n"
+                                + "  /// one long incredibly"
+                                + " unbroken sentence moving from topic to topic so that no-one had a"
+                                + " chance to interrupt;\n"
+                                + "  void m() {}\n"
+                                + "}\n"))
+                .isEqualTo("class T {\n"
+                        + "  /// one long incredibly unbroken sentence moving from topic to topic so that"
+                        + " no-one had a chance\n"
+                        + "  /// to interrupt;\n"
+                        + "  void m() {}\n"
+                        + "}\n");
+    }
+
+    @Test
     public void dontWrapMoeLineComments() throws Exception {
         assertThat(Formatter.create()
                         .formatSource("class T {\n"


### PR DESCRIPTION
## Before this PR
When there was a very long markdown docstring comment (beginning with `///`), the formatter would break the comment up, but would only add `//` to the beginning of the new line instead of `///`.

```java
/// Very long markdown docstring with an arbitrary cutoff
class MyClass {}
``` 

```java
/// Very long markdown docstring with an arbitrary
// cutoff
class MyClass {}
``` 

## After this PR
==COMMIT_MSG==
Fix issue when wrapping markdown docstrings resulted in 2 slashes instead of 3
==COMMIT_MSG==

## Possible downsides?
This fix piggybacks on the regular comment line formatting instead of teaching the formatter about markdown docstring comments. I think this is fine as a quick fix, but if any more problems come up with markdown docstring comments we should look into creating a dedicated formatter.
