### PR TITLE
Only run the formatter on trusted projects

### DIFF
--- a/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
+++ b/idea-plugin/src/main/java/com/palantir/javaformat/intellij/PalantirJavaFormatFormattingService.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Range;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.ide.impl.TrustedProjects;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsSafe;
@@ -45,6 +46,13 @@ class PalantirJavaFormatFormattingService extends AsyncDocumentFormattingService
     @Override
     protected FormattingTask createFormattingTask(@NotNull AsyncFormattingRequest request) {
         Project project = request.getContext().getProject();
+        if (!TrustedProjects.isTrusted(project)) {
+            logger.warn("palantir-java-format: skipping formatting for untrusted project: " + project.getName());
+            request.onError(
+                    Notifications.GENERIC_ERROR_NOTIFICATION_GROUP,
+                    "palantir-java-format requires a trusted project to load the external formatter classpath.");
+            return null;
+        }
         PalantirJavaFormatSettings settings = PalantirJavaFormatSettings.getInstance(project);
         Optional<FormatterService> formatter = formatterProvider.get(project, settings);
         return new PalantirJavaFormatFormattingTask(request, formatter);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
internal thread [here](https://pl.ntr/2C2)

==COMMIT_MSG==
Only run the formatter on trusted projects
==COMMIT_MSG==

Tested locally by running `./gradlew runIde`
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

