### PR TITLE
Fix Spotless targetExclude patterns being overridden

### DIFF
--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -54,14 +54,15 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
         // Exclude generated source directories
         // Note: We cannot simply exclude **/build/**/* because some repos might contain a build directory
         // within the src sourceset that should be formatted.
-        java.targetExclude("**/build/generated*/**");
-        java.targetExclude("**/src/generated*/**");
-        java.targetExclude("**/generated_*src/**");
-        java.targetExclude("**/generated_*Src/**");
-        // build/groovy-dsl-plugins contains Java wrapper classes for
-        // https://docs.gradle.org/9.3.1/userguide/implementing_gradle_plugins_convention.html
-        // and don't need to be formatted.
-        java.targetExclude("**/groovy-dsl-plugins/**");
+        java.targetExclude(
+                "**/build/generated*/**",
+                "**/src/generated*/**",
+                "**/generated_*src/**",
+                "**/generated_*Src/**",
+                // build/groovy-dsl-plugins contains Java wrapper classes for
+                // https://docs.gradle.org/9.3.1/userguide/implementing_gradle_plugins_convention.html
+                // and don't need to be formatted.
+                "**/groovy-dsl-plugins/**");
         // This is configuration cache safe as happening afterEvaluate
         java.addStep(spotlessJavaFormatStep());
     }

--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/SpotlessInterop.java
@@ -52,9 +52,9 @@ public abstract class SpotlessInterop implements Action<JavaExtension> {
     @Override
     public void execute(JavaExtension java) {
         // Exclude generated source directories
-        // Note: We cannot simply exclude **/build/**/* because some repos might contain a build directory
-        // within the src sourceset that should be formatted.
         java.targetExclude(
+                // Note: We cannot simply exclude **/build/**/* because some repos might contain a build directory
+                // within the src sourceset that should be formatted.
                 "**/build/generated*/**",
                 "**/src/generated*/**",
                 "**/generated_*src/**",

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
@@ -24,7 +24,6 @@ import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.io.File;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -64,8 +63,9 @@ class SpotlessExcludesTest {
                 "build/generated/java",
                 "src/generated/java",
                 "src/main/generated_testsrc",
+                "src/main/generated_foo_testsrc",
                 "generated_testSrc",
-                "build/groovy-dsl-plugins/output",
+                "build/groovy-dsl-plugins/output"
             })
     void format_ignores_excluded_directories(String srcDir, GradleInvoker gradle, RootProject project) {
         project.buildGradle().append("""
@@ -87,9 +87,22 @@ class SpotlessExcludesTest {
         assertThat(result).task(":spotlessJava").succeeded();
     }
 
-    @Test
-    void format_checks_non_generated_files(GradleInvoker gradle, RootProject project) {
-        project.file("src/main/java/test/generatedNamespace/Test.java").overwrite("""
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "foo/generated_foo/src/bar",
+                "src/main/java/test/generatedNamespace",
+            })
+    void format_checks_non_generated_files(String srcDir, GradleInvoker gradle, RootProject project) {
+        project.buildGradle().append("""
+            sourceSets {
+                main {
+                    java { srcDir '%s' }
+                }
+            }
+            """, srcDir);
+
+        project.file(srcDir + "/Test.java").overwrite("""
             package test;
             import java.lang.Void;
             public class Test { Void test() { return null; } }

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
@@ -89,7 +89,7 @@ class SpotlessExcludesTest {
 
     @Test
     void format_checks_non_generated_files(GradleInvoker gradle, RootProject project) {
-        project.file("src/main/java/test/Test.java").overwrite("""
+        project.file("src/main/java/test/generatedNamespace/Test.java").overwrite("""
             package test;
             import java.lang.Void;
             public class Test { Void test() { return null; } }

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.javaformat.gradle;
+
+import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import java.io.File;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@GradlePluginTests
+@DisabledConfigurationCache
+class SpotlessExcludesTest {
+
+    private static final String CLASSPATH_FILE = new File("build/impl.classpath").getAbsolutePath();
+
+    @BeforeEach
+    void setup(RootProject project) {
+        project.buildGradle()
+                .plugins()
+                .add("java")
+                .add("com.palantir.java-format")
+                .add("com.diffplug.spotless");
+
+        project.buildGradle().append("""
+            dependencies {
+                palantirJavaFormat files(file("%s").text.split(':'))
+            }
+            """, CLASSPATH_FILE);
+        // Add jvm args to allow spotless and formatter gradle plugins to run with Java 16+
+        project.gradlePropertiesFile()
+                .appendProperty(
+                        "org.gradle.jvmargs",
+                        "--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED "
+                                + "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED "
+                                + "--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED "
+                                + "--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED "
+                                + "--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "build/generated/java",
+                "src/generated/java",
+                "src/main/generated_testsrc",
+                "generated_testSrc",
+                "build/groovy-dsl-plugins/output",
+            })
+    void format_ignores_excluded_directories(String srcDir, GradleInvoker gradle, RootProject project) {
+        project.buildGradle().append("""
+            sourceSets {
+                main {
+                    java { srcDir '%s' }
+                }
+            }
+            """, srcDir);
+
+        project.file(srcDir + "/test/Test.java").overwrite("""
+            package test;
+            import java.lang.Void;
+            public class Test { Void test() { return null; } }
+            """);
+
+        InvocationResult result = gradle.withArgs("spotlessJavaCheck").buildsSuccessfully();
+
+        assertThat(result).task(":spotlessJava").succeeded();
+    }
+}

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SpotlessExcludesTest.java
@@ -24,6 +24,7 @@ import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.io.File;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -82,6 +83,19 @@ class SpotlessExcludesTest {
             """);
 
         InvocationResult result = gradle.withArgs("spotlessJavaCheck").buildsSuccessfully();
+
+        assertThat(result).task(":spotlessJava").succeeded();
+    }
+
+    @Test
+    void format_checks_non_generated_files(GradleInvoker gradle, RootProject project) {
+        project.file("src/main/java/test/Test.java").overwrite("""
+            package test;
+            import java.lang.Void;
+            public class Test { Void test() { return null; } }
+            """);
+
+        InvocationResult result = gradle.withArgs("spotlessJavaCheck").buildsWithFailure();
 
         assertThat(result).task(":spotlessJava").succeeded();
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
https://github.com/palantir/palantir-java-format/pull/1568 was not additive, calling `targetExclude `multiple times was overriding previous values instead of accumulating them.

## After this PR
FLUP for https://github.com/palantir/palantir-java-format/pull/1568
- Fix `SpotlessInterop` calling `targetExclude` multiple times, which overrides previous patterns instead of accumulating them - only the last exclude (`**/groovy-dsl-plugins/**`)  was actually applied
- Add `SpotlessExcludesTest` to verify `spotlessJavaCheck` skips files in all excluded  directories

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix Spotless targetExclude patterns being overridden
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

