### PR TITLE
 Fix duplicate class entries in `instrumentedJar` that block plugin publishin

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(jar tf *)",
+      "Bash(gradle -q help)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(jar tf *)",
-      "Bash(gradle -q help)"
-    ]
-  }
-}

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -76,6 +76,10 @@ tasks.named("javadoc", Javadoc) {
     failOnError = false
 }
 
-tasks.withType(Jar).configureEach {
+// Prevent duplicate class entries in the instrumentedJar, which the JetBrains marketplace rejects.
+// The jar task's duplicatesStrategy is overridden from INHERIT to WARN. The instrumentedJar task
+// uses with(jarTask) to include the jar's CopySpec, so it picks up WARN and allows duplicates through.
+// Setting EXCLUDE here on the jar task propagates into instrumentedJar via that with(jarTask) call.
+tasks.named('jar') {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -75,3 +75,7 @@ dependencies {
 tasks.named("javadoc", Javadoc) {
     failOnError = false
 }
+
+tasks.named('jar') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -76,6 +76,6 @@ tasks.named("javadoc", Javadoc) {
     failOnError = false
 }
 
-tasks.named('jar') {
+tasks.withType(Jar).configureEach {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- The instrumentedJar task produces a JAR with duplicate class entries (e.g. `FormatterProvider$FormatterCacheKey.class`), which the JetBrains plugin marketplace now rejects.
-  The jar task's duplicatesStrategy is overridden from `INHERIT` to `WARN` by a plugin?, and `instrumentedJar` picks this up via `with(jarTask)`, allowing duplicates through (see code [here](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/v1.17.4/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt#L1187))
 
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Setting `EXCLUDE `on the jar task propagates into `instrumentedJar` and prevents the duplicates   

==COMMIT_MSG==
 Fix duplicate class entries in `instrumentedJar` that block plugin publishin
==COMMIT_MSG==

FLUP: move to intellij gradle plugin 2.x https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

