### PR TITLE
Fix/preserve snippet javadoc newlines

### DIFF
--- a/changelog/@unreleased/pr-1717.v2.yml
+++ b/changelog/@unreleased/pr-1717.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Preserve newlines and prevent spurious `<p>` tags inside `{@snippet}` Javadoc blocks
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1717

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocFormatter.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocFormatter.java
@@ -103,6 +103,12 @@ public final class JavadocFormatter {
                 case CODE_CLOSE_TAG:
                     output.writeCodeClose(token);
                     break;
+                case SNIPPET_TAG_OPEN:
+                    output.writeSnippetOpen(token);
+                    break;
+                case SNIPPET_TAG_CLOSE:
+                    output.writeSnippetClose(token);
+                    break;
                 case TABLE_OPEN_TAG:
                     output.writeTableOpen(token);
                     break;

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocLexer.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocLexer.java
@@ -254,8 +254,7 @@ final class JavadocLexer {
     }
 
     private boolean preserveExistingFormatting() {
-        return preDepth.isPositive() || tableDepth.isPositive() || codeDepth.isPositive()
-                || snippetDepth.isPositive();
+        return preDepth.isPositive() || tableDepth.isPositive() || codeDepth.isPositive() || snippetDepth.isPositive();
     }
 
     private void checkMatchingTags() throws LexException {

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocLexer.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocLexer.java
@@ -44,6 +44,8 @@ import static com.palantir.javaformat.java.javadoc.Token.Type.PARAGRAPH_CLOSE_TA
 import static com.palantir.javaformat.java.javadoc.Token.Type.PARAGRAPH_OPEN_TAG;
 import static com.palantir.javaformat.java.javadoc.Token.Type.PRE_CLOSE_TAG;
 import static com.palantir.javaformat.java.javadoc.Token.Type.PRE_OPEN_TAG;
+import static com.palantir.javaformat.java.javadoc.Token.Type.SNIPPET_TAG_CLOSE;
+import static com.palantir.javaformat.java.javadoc.Token.Type.SNIPPET_TAG_OPEN;
 import static com.palantir.javaformat.java.javadoc.Token.Type.TABLE_CLOSE_TAG;
 import static com.palantir.javaformat.java.javadoc.Token.Type.TABLE_OPEN_TAG;
 import static com.palantir.javaformat.java.javadoc.Token.Type.WHITESPACE;
@@ -98,6 +100,7 @@ final class JavadocLexer {
     private final NestingCounter preDepth = new NestingCounter();
     private final NestingCounter codeDepth = new NestingCounter();
     private final NestingCounter tableDepth = new NestingCounter();
+    private final NestingCounter snippetDepth = new NestingCounter();
     private boolean somethingSinceNewline;
 
     private JavadocLexer(CharStream input) {
@@ -159,7 +162,11 @@ final class JavadocLexer {
         }
         somethingSinceNewline = true;
 
-        if (input.tryConsumeRegex(INLINE_TAG_OPEN_PATTERN)) {
+        if (input.tryConsumeRegex(SNIPPET_INLINE_TAG_OPEN_PATTERN)) {
+            braceDepth.increment();
+            snippetDepth.increment();
+            return SNIPPET_TAG_OPEN;
+        } else if (input.tryConsumeRegex(INLINE_TAG_OPEN_PATTERN)) {
             braceDepth.increment();
             return INLINE_TAG_OPEN;
         } else if (input.tryConsume("{")) {
@@ -167,7 +174,14 @@ final class JavadocLexer {
             return LITERAL;
         } else if (input.tryConsume("}")) {
             braceDepth.decrementIfPositive();
-            return braceDepth.isPositive() ? LITERAL : INLINE_TAG_CLOSE;
+            if (!braceDepth.isPositive()) {
+                if (snippetDepth.isPositive()) {
+                    snippetDepth.decrementIfPositive();
+                    return SNIPPET_TAG_CLOSE;
+                }
+                return INLINE_TAG_CLOSE;
+            }
+            return LITERAL;
         }
 
         // Inside an inline tag, don't do any HTML interpretation.
@@ -240,7 +254,8 @@ final class JavadocLexer {
     }
 
     private boolean preserveExistingFormatting() {
-        return preDepth.isPositive() || tableDepth.isPositive() || codeDepth.isPositive();
+        return preDepth.isPositive() || tableDepth.isPositive() || codeDepth.isPositive()
+                || snippetDepth.isPositive();
     }
 
     private void checkMatchingTags() throws LexException {
@@ -541,6 +556,7 @@ final class JavadocLexer {
     private static final Pattern BLOCKQUOTE_OPEN_PATTERN = openTagPattern("blockquote");
     private static final Pattern BLOCKQUOTE_CLOSE_PATTERN = closeTagPattern("blockquote");
     private static final Pattern BR_PATTERN = openTagPattern("br");
+    private static final Pattern SNIPPET_INLINE_TAG_OPEN_PATTERN = compile("^[{]@snippet\\b");
     private static final Pattern INLINE_TAG_OPEN_PATTERN = compile("^[{]@\\w*");
     /*
      * We exclude < so that we don't swallow following HTML tags. This lets us fix up "foo<p>" (~400

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocWriter.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/JavadocWriter.java
@@ -214,6 +214,20 @@ final class JavadocWriter {
         writeToken(token);
     }
 
+    void writeSnippetOpen(Token token) {
+        if (wroteAnythingSignificant) {
+            requestBlankLine();
+        }
+
+        writeToken(token);
+    }
+
+    void writeSnippetClose(Token token) {
+        writeToken(token);
+
+        requestBlankLine();
+    }
+
     void writeTableOpen(Token token) {
         requestBlankLine();
 

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/Token.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/javadoc/Token.java
@@ -54,6 +54,8 @@ final class Token {
         PRE_CLOSE_TAG,
         CODE_OPEN_TAG,
         CODE_CLOSE_TAG,
+        SNIPPET_TAG_OPEN,
+        SNIPPET_TAG_CLOSE,
         TABLE_OPEN_TAG,
         TABLE_CLOSE_TAG,
         /** {@code <!-- MOE：begin_intracomment_strip -->} */

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
@@ -1419,22 +1419,10 @@ public final class JavadocFormattingTest {
     @Test
     public void snippetBlockWithLangAttributePreservesNewlines() {
         String[] input = {
-            "/**",
-            " * {@snippet lang=\"properties\" :",
-            " * foo=\\",
-            " * bar",
-            " * }",
-            " */",
-            "class Test {}",
+            "/**", " * {@snippet lang=\"properties\" :", " * foo=\\", " * bar", " * }", " */", "class Test {}",
         };
         String[] expected = {
-            "/**",
-            " * {@snippet lang=\"properties\" :",
-            " * foo=\\",
-            " * bar",
-            " * }",
-            " */",
-            "class Test {}",
+            "/**", " * {@snippet lang=\"properties\" :", " * foo=\\", " * bar", " * }", " */", "class Test {}",
         };
         doFormatTest(input, expected);
     }

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavadocFormattingTest.java
@@ -1388,6 +1388,116 @@ public final class JavadocFormattingTest {
     }
 
     @Test
+    public void snippetBlockPreservesNewlines() {
+        String[] input = {
+            "/**",
+            " * Example:",
+            " *",
+            " * {@snippet :",
+            " * class FooFactory {",
+            " *     Foo getFoo() { return null; }",
+            " * }",
+            " * }",
+            " */",
+            "class Test {}",
+        };
+        String[] expected = {
+            "/**",
+            " * Example:",
+            " *",
+            " * {@snippet :",
+            " * class FooFactory {",
+            " *     Foo getFoo() { return null; }",
+            " * }",
+            " * }",
+            " */",
+            "class Test {}",
+        };
+        doFormatTest(input, expected);
+    }
+
+    @Test
+    public void snippetBlockWithLangAttributePreservesNewlines() {
+        String[] input = {
+            "/**",
+            " * {@snippet lang=\"properties\" :",
+            " * foo=\\",
+            " * bar",
+            " * }",
+            " */",
+            "class Test {}",
+        };
+        String[] expected = {
+            "/**",
+            " * {@snippet lang=\"properties\" :",
+            " * foo=\\",
+            " * bar",
+            " * }",
+            " */",
+            "class Test {}",
+        };
+        doFormatTest(input, expected);
+    }
+
+    @Test
+    public void snippetBlockFollowedByBodyText() {
+        String[] input = {
+            "/**",
+            " * Description.",
+            " *",
+            " * {@snippet :",
+            " * code here",
+            " * }",
+            " *",
+            " * More text.",
+            " */",
+            "class Test {}",
+        };
+        String[] expected = {
+            "/**",
+            " * Description.",
+            " *",
+            " * {@snippet :",
+            " * code here",
+            " * }",
+            " *",
+            " * More text.",
+            " */",
+            "class Test {}",
+        };
+        doFormatTest(input, expected);
+    }
+
+    @Test
+    public void snippetBlockFollowedByFooterTag() {
+        String[] input = {
+            "/**",
+            " * Description.",
+            " *",
+            " * {@snippet :",
+            " * code here",
+            " * }",
+            " *",
+            " * @param foo the foo",
+            " */",
+            "class Test {}",
+        };
+        String[] expected = {
+            "/**",
+            " * Description.",
+            " *",
+            " * {@snippet :",
+            " * code here",
+            " * }",
+            " *",
+            " * @param foo the foo",
+            " */",
+            "class Test {}",
+        };
+        doFormatTest(input, expected);
+    }
+
+    @Test
     public void windowsLineSeparator() throws FormatterException {
         String[] input = {
             "/**", " * hello", " *", " * <p>world", " */", "class Test {}",


### PR DESCRIPTION
## Before this PR

The Javadoc formatter corrupts `{@snippet}` blocks in two ways:

1. **Newline collapsing** — `preserveExistingFormatting()` did not account for snippet depth, so the lexer's whitespace-joining logic folded multi-line snippet bodies onto a single line.
2. **Spurious `<p>` injection** — snippet content was tokenized as generic `LITERAL` tokens, so `inferParagraphTags()` preceded it with a `<p>` tag.

Both defects produce invalid Javadoc. The `{@snippet}` inline-body form requires the colon (`:`) to be the last character before a newline; placing body content on the same line as `:` is a spec violation that `javadoc` rejects as `error: unexpected content`.

### Concrete example

Given this correctly-formatted source:

```java
/**
 * Example showing how to use the component:
 *
 * {@snippet :
 *     MyComponent component = new MyComponent();
 *     component.configure("key", "value");
 *     component.run();
 * }
 */
public class Demo {}
```

After running spotless with `palantirJavaFormat` 2.96.0 and `formatJavadoc=true`:

```java
/**
 * Example showing how to use the component:
 *
 * <p>{@snippet : MyComponent component = new MyComponent(); component.configure("key", "value"); component.run(); }
 */
public class Demo {}
```

Running `javadoc` on this output:

```
Demo.java:4: error: unexpected content
 * <p>{@snippet : MyComponent component = new MyComponent(); component.configure("key", "value"); component.run(); }
                ^
Demo.java:4: warning: invalid usage of tag {@snippet :
 * <p>{@snippet : MyComponent component = new MyComponent(); component.configure("key", "value"); component.run(); }
                ^
1 error, 1 warning
```

## After this PR

`{@snippet}` blocks are treated like `<pre>` blocks — internal newlines are preserved and no `<p>` tags are injected.

After running spotless with `palantirJavaFormat` 2.97.0 and `formatJavadoc=true`, the same source is left unchanged and `javadoc` produces no errors.

Two dedicated token types (`SNIPPET_TAG_OPEN`, `SNIPPET_TAG_CLOSE`) are introduced, mirroring the existing `PRE_OPEN_TAG` / `PRE_CLOSE_TAG` pattern. This causes `inferParagraphTags()` and `joinAdjacentLiteralsAndAdjacentWhitespace()` to skip snippet content automatically, without any special-case branching in those methods.

## Possible downsides?

Javadoc comments containing `{@snippet}` blocks will be reformatted on first run. The output will be correct, but it is a one-time diff for any project that uses `{@snippet}` with `formatJavadoc` enabled.
