### PR TITLE
feat(map-format): format key-value pairs to be inline

### DIFF
--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -3269,9 +3269,14 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         return MAP_FACTORY_TYPES.contains(receiverName);
     }
 
-    private static final ImmutableSet<String> MAP_FACTORY_TYPES =
-            ImmutableSet.of("Map", "ImmutableMap", "ImmutableSortedMap", "ImmutableBiMap", "SortedMap", "NavigableMap",
-                    "ConcurrentMap");
+    private static final ImmutableSet<String> MAP_FACTORY_TYPES =ImmutableSet.of(
+            "Map",
+            "ImmutableMap",
+            "ImmutableSortedMap",
+            "ImmutableBiMap",
+            "SortedMap",
+            "NavigableMap",
+            "ConcurrentMap");
 
     private void argList(List<? extends ExpressionTree> arguments) {
         builder.open(OpenOp.builder()

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaInputAstVisitor.java
@@ -707,7 +707,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             builder.addAll(visitModifiers(node.getClassBody().getModifiers(), Direction.HORIZONTAL, Optional.empty()));
         }
         scan(node.getIdentifier(), null);
-        addArguments(node.getArguments(), plusFour);
+        addArguments(node.getArguments(), plusFour, /* isMapFactory= */ false);
         builder.close();
         if (node.getClassBody() != null) {
             addBodyDeclarations(node.getClassBody().getMembers(), BracesOrNot.YES, FirstDeclarationsOrNot.YES);
@@ -807,7 +807,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             builder.guessToken("(");
             builder.guessToken(")");
         } else {
-            addArguments(init.getArguments(), plusFour);
+            addArguments(init.getArguments(), plusFour, /* isMapFactory= */ false);
         }
         if (init.getClassBody() != null) {
             addBodyDeclarations(init.getClassBody().getMembers(), BracesOrNot.YES, FirstDeclarationsOrNot.YES);
@@ -3092,7 +3092,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                         .debugName("dotExpressionArgsAndParen")
                         .build());
                 MethodInvocationTree methodInvocation = (MethodInvocationTree) expression;
-                addArguments(methodInvocation.getArguments(), indent);
+                addArguments(methodInvocation.getArguments(), indent, isMapFactory(methodInvocation));
                 builder.close();
                 break;
             default:
@@ -3156,8 +3156,9 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
      *
      * @param arguments the arguments
      * @param plusIndent the extra indent for the arguments
+     * @param isMapFactory whether the arguments are key-value pairs of a map factory method such as {@code Map.of}
      */
-    void addArguments(List<? extends ExpressionTree> arguments, Indent plusIndent) {
+    void addArguments(List<? extends ExpressionTree> arguments, Indent plusIndent, boolean isMapFactory) {
         /*
          `preferBreakingLastInnerLevel` here in order to avoid immediately breaking a long
          invocation that can be one-lined:
@@ -3183,7 +3184,27 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
                 .build());
         token("(");
         if (!arguments.isEmpty()) {
-            if (arguments.size() % 2 == 0 && argumentsAreTabular(arguments) == 2) {
+            if (isMapFactory && arguments.size() % 2 == 0) {
+                builder.breakOp();
+                builder.open(ZERO);
+                boolean first = true;
+                for (int i = 0; i < arguments.size() - 1; i += 2) {
+                    ExpressionTree argument0 = arguments.get(i);
+                    ExpressionTree argument1 = arguments.get(i + 1);
+                    if (!first) {
+                        token(",");
+                        builder.breakOp(" ");
+                    }
+                    builder.open(plusFour);
+                    scan(argument0, null);
+                    token(",");
+                    builder.breakOp(" ");
+                    scan(argument1, null);
+                    builder.close();
+                    first = false;
+                }
+                builder.close();
+            } else if (arguments.size() % 2 == 0 && argumentsAreTabular(arguments) == 2) {
                 builder.forcedBreak();
                 builder.open(ZERO);
                 boolean first = true;
@@ -3221,6 +3242,36 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         token(")");
         builder.close();
     }
+
+    /**
+     * Returns true if the given method invocation is a map factory method such as {@code Map.of} or
+     * {@code ImmutableMap.of}, whose arguments are alternating keys and values.
+     */
+    private static boolean isMapFactory(MethodInvocationTree methodInvocation) {
+        ExpressionTree receiver = Trees.getMethodReceiver(methodInvocation);
+        if (receiver == null) {
+            return false;
+        }
+        if (!getMethodName(methodInvocation).contentEquals("of")) {
+            return false;
+        }
+        String receiverName;
+        switch (receiver.getKind()) {
+            case IDENTIFIER:
+                receiverName = ((IdentifierTree) receiver).getName().toString();
+                break;
+            case MEMBER_SELECT:
+                receiverName = ((MemberSelectTree) receiver).getIdentifier().toString();
+                break;
+            default:
+                return false;
+        }
+        return MAP_FACTORY_TYPES.contains(receiverName);
+    }
+
+    private static final ImmutableSet<String> MAP_FACTORY_TYPES =
+            ImmutableSet.of("Map", "ImmutableMap", "ImmutableSortedMap", "ImmutableBiMap", "SortedMap", "NavigableMap",
+                    "ConcurrentMap");
 
     private void argList(List<? extends ExpressionTree> arguments) {
         builder.open(OpenOp.builder()

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/MapOf.input
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/MapOf.input
@@ -1,0 +1,19 @@
+class T {
+  Map<String, String> small = Map.of("one", "alpha", "two", "beta");
+
+  Map<String, String> big = Map.of(
+      "very long key number one", "very long value number one",
+      "very long key number two", "very long value number two",
+      "very long key number three", "very long value number three",
+      "very long key number four", "very long value number four");
+
+  Map<String, String> immutable = ImmutableMap.of(
+      "very long key number one", "very long value number one",
+      "very long key number two", "very long value number two",
+      "very long key number three", "very long value number three");
+
+  Map<String, String> oddArgs = Map.of(
+      "very long key number one", "very long value number one",
+      "very long key number two", "very long value number two",
+      "very long key number three");
+}

--- a/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/MapOf.output
+++ b/palantir-java-format/src/test/resources/com/palantir/javaformat/java/testdata/MapOf.output
@@ -1,0 +1,21 @@
+class T {
+    Map<String, String> small = Map.of("one", "alpha", "two", "beta");
+
+    Map<String, String> big = Map.of(
+            "very long key number one", "very long value number one",
+            "very long key number two", "very long value number two",
+            "very long key number three", "very long value number three",
+            "very long key number four", "very long value number four");
+
+    Map<String, String> immutable = ImmutableMap.of(
+            "very long key number one", "very long value number one",
+            "very long key number two", "very long value number two",
+            "very long key number three", "very long value number three");
+
+    Map<String, String> oddArgs = Map.of(
+            "very long key number one",
+            "very long value number one",
+            "very long key number two",
+            "very long value number two",
+            "very long key number three");
+}


### PR DESCRIPTION
## Before this PR
the static factory methods for Map and ImmutableMaps are treated as regular methods, where each argument is expected to be in a new line. But for these methods, it makes more sense to have the key-value pairs inline, for better readability and context.

## After this PR
the key-value pairs of Map factory method will be in the same line, allowing for better readability.

## Possible downsides?
previously correctly formatted files will now show up as failing formatting checks and can potentially create a big diff across a lot of files. 

closes: https://github.com/palantir/palantir-java-format/issues/1602