### PR TITLE
Allow Java Format without Spotless

### DIFF
--- a/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPlugin.java
+++ b/gradle-palantir-java-format/src/main/java/com/palantir/javaformat/gradle/PalantirJavaFormatSpotlessPlugin.java
@@ -35,10 +35,11 @@ public abstract class PalantirJavaFormatSpotlessPlugin implements Plugin<Project
         Supplier<FormatterService> memoizedService =
                 rootProject.getExtensions().getByType(JavaFormatExtension.class)::serviceLoad;
 
-        SpotlessInterop spotlessInterop = rootProject.getObjects().newInstance(SpotlessInterop.class, memoizedService);
         project.getPluginManager().withPlugin("java", _javaPlugin -> {
             SPOTLESS_PLUGINS.forEach(spotlessPluginId -> project.getPluginManager()
                     .withPlugin(spotlessPluginId, _spotlessPlugin -> {
+                        SpotlessInterop spotlessInterop =
+                                rootProject.getObjects().newInstance(SpotlessInterop.class, memoizedService);
                         SpotlessExtension spotlessExtension =
                                 project.getExtensions().getByType(SpotlessExtension.class);
                         spotlessExtension.java(spotlessInterop);

--- a/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SupportsMissingSpotlessTest.java
+++ b/gradle-palantir-java-format/src/test/java/com/palantir/javaformat/gradle/SupportsMissingSpotlessTest.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.gradle;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+class SupportsMissingSpotlessTest {
+
+    @Test
+    void can_be_applied_when_spotless_is_not_on_the_classpath() {
+        assertThatThrownBy(() -> Class.forName("com.diffplug.gradle.spotless.SpotlessExtension"))
+                .as("spotless must be off the test classpath for this test to be meaningful")
+                .isInstanceOf(ClassNotFoundException.class);
+
+        Project project = ProjectBuilder.builder().build();
+
+        assertThatCode(() -> project.getPluginManager().apply(PalantirJavaFormatSpotlessPlugin.class))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Before this PR

Applying the Java Format Gradle plugin without Spotless on the buildscript classpath fails on Gradle 9. `PalantirJavaFormatSpotlessPlugin` eagerly creates `SpotlessInterop`, so Gradle resolves its `FormatterStep` dependency even when no Spotless plugin is applied.

## After this PR

`SpotlessInterop` is created only after both Java and Spotless are applied. Projects can use Java Format without putting Spotless on the buildscript classpath.

==COMMIT_MSG==
==COMMIT_MSG==

## Testing

A regression test verifies that `PalantirJavaFormatSpotlessPlugin` can be applied when Spotless is absent. The existing Spotless compatibility matrix, Error Prone, formatting, and Checkstyle checks pass. Three affected Gradle 9.7 builds also configure successfully with the locally published fix.

## Possible downsides?

None known. Spotless integration is initialised at the same point that it is used: after a supported Spotless plugin is applied.

## Are Docs needed?

No. This restores the existing optional integration behaviour.
