### PR TITLE
Support IntelliJ Platform Gradle Plugin 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ fileeditor
 *.ipr
 *.iws
 .idea/
+.intellijPlatform/
 out/
 
 # Eclipse/IntelliJ APT

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.palantir.baseline-error-prone:gradle-baseline-error-prone:0.7.0'
         classpath 'com.palantir.baseline:gradle-baseline-java:6.80.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:3.19.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.37.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:2.0.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.21.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:5.1.0'
         classpath 'com.palantir.gradle.guide:gradle-guide:1.27.0'

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -35,6 +35,11 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
+    pluginVerification {
+        ides {
+            create('IC', '2024.1')
+        }
+    }
 }
 
 configurations {

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 apply plugin: 'java'
 apply plugin: 'com.palantir.external-publish-intellij'
 
 def name = "palantir-java-format"
-intellij {
-    pluginName = name
-    updateSinceUntilBuild = true
-    version = "2024.1"
-    plugins = ['java']
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
-patchPluginXml {
-    pluginDescription = "Formats source code using the palantir-java-format tool."
-    sinceBuild = '241' // TODO: keep the intellij version & sinceBuild in sync
-    untilBuild = ''
+intellijPlatform {
+    projectName = name
+    pluginConfiguration {
+        description = 'Formats source code using the palantir-java-format tool.'
+        ideaVersion {
+            sinceBuild = '241' // TODO: keep the intellij version & sinceBuild in sync
+            untilBuild = provider { null }
+        }
+    }
 }
 
 configurations {
@@ -42,8 +48,8 @@ configurations {
 
 // This task will resolve runtimeClasspath without telling Gradle that it depends on it, therefore dependent jars won't
 // be created beforehand. Therefore, ensure that it knows about it.
-// see https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/groovy/org/jetbrains/intellij/tasks/PrepareSandboxTask.groovy
-tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask).configureEach {
+// see https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/main/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
+tasks.withType(org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask).configureEach {
     dependsOn configurations.runtimeClasspath
 
     // Also pack the formatter in its own directory
@@ -55,6 +61,15 @@ tasks.withType(org.jetbrains.intellij.tasks.PrepareSandboxTask).configureEach {
 }
 
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity('2024.1') {
+            useInstaller = false
+        }
+        bundledPlugins('com.intellij.java')
+        testFramework(TestFrameworkType.Platform.INSTANCE)
+        testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
+    }
+
     implementation project(':palantir-java-format-jdk-bootstrap')
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation('com.palantir.sls.versions:sls-versions') {
@@ -66,6 +81,7 @@ dependencies {
     formatter project(':palantir-java-format')
 
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'junit:junit'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.platform:junit-platform-launcher'
     implementation 'com.google.code.findbugs:jsr305'

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-
 apply plugin: 'java'
 apply plugin: 'com.palantir.external-publish-intellij'
 
@@ -31,13 +29,15 @@ intellijPlatform {
     pluginConfiguration {
         description = 'Formats source code using the palantir-java-format tool.'
         ideaVersion {
-            sinceBuild = '241' // TODO: keep the intellij version & sinceBuild in sync
+            // sinceBuild derives from the intellijIdeaCommunity() version
             untilBuild = provider { null }
         }
     }
     pluginVerification {
         ides {
             create('IC', '2024.1')
+            create('IU', '2025.3.6.1')
+            create('IU', '2026.2.2')
         }
     }
 }
@@ -71,8 +71,6 @@ dependencies {
             useInstaller = false
         }
         bundledPlugins('com.intellij.java')
-        testFramework(TestFrameworkType.Platform.INSTANCE)
-        testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
     }
 
     implementation project(':palantir-java-format-jdk-bootstrap')

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 apply plugin: 'java'
 apply plugin: 'com.palantir.external-publish-intellij'
 
@@ -71,6 +73,8 @@ dependencies {
             useInstaller = false
         }
         bundledPlugins('com.intellij.java')
+        testFramework(TestFrameworkType.Platform.INSTANCE)
+        testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
     }
 
     implementation project(':palantir-java-format-jdk-bootstrap')


### PR DESCRIPTION
## Before this PR

[`gradle-external-publish-plugin` `2.0.0`](https://github.com/palantir/gradle-external-publish-plugin/releases/tag/2.0.0) uses IntelliJ Platform Gradle Plugin 2.x. This repository still uses its removed 1.x DSL and cannot consume the release. JetBrains documents the required changes in the [migration guide](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html).

## After this PR

==COMMIT_MSG==
==COMMIT_MSG==

The build consumes `gradle-external-publish-plugin` `2.0.0` and uses the IntelliJ Platform 2.x DSL. Existing IntelliJ versions, compatibility bounds, metadata, bundled plugins, and verifier targets remain unchanged.

## Testing

- The IntelliJ plugin tests pass.
- `buildPlugin` passes.
- Formatting, Error Prone, and Checkstyle checks pass.

## Possible downsides?

None known.

## Are Docs needed?

No.
