### PR TITLE
Keep the comment prefix when wrapping a markdown docstring

### DIFF
--- a/changelog/@unreleased/pr-1776.v2.yml
+++ b/changelog/@unreleased/pr-1776.v2.yml
@@ -1,0 +1,16 @@
+type: fix
+fix:
+  description: |-
+    Wrapping a markdown documentation comment (`///`, JEP 467) no longer drops the `///`
+    from the wrapped line. From JDK 23 on javac returns a run of `///` lines as one comment
+    token, so the prefix was read from a line that still carried its source indentation and
+    came back empty: in Google style the output did not compile (`illegal start of type`),
+    and in Palantir style a trailing word such as `@Deprecated` became an annotation on the
+    following declaration, which compiles. The indentation was also counted twice in the
+    width test, so lines under the column limit were wrapped.
+
+    An unbreakable token is now left long rather than producing an empty `///` followed by
+    bare text, and `///foo` -> `/// foo` applies to every line of the run, so the same source
+    formats identically whichever JDK runs the formatter.
+  links:
+  - https://github.com/palantir/palantir-java-format/pull/1776

--- a/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
+++ b/palantir-java-format/src/main/java/com/palantir/javaformat/java/JavaCommentsHelper.java
@@ -124,6 +124,12 @@ public final class JavaCommentsHelper implements CommentsHelper {
     private List<String> wrapLineComments(List<String> lines, int column0) {
         List<String> result = new ArrayList<>();
         for (String line : lines) {
+            // From JDK 23 on, javac returns a run of `///` markdown lines as a single comment tok, so
+            // every line after the first still carries its source indentation. indentLineComments
+            // trims and re-indents all of them, so both the slash prefix and the width budget have to
+            // be read from the trimmed text: otherwise the prefix comes back empty and the wrapped
+            // remainder is emitted as bare code.
+            line = CharMatcher.whitespace().trimLeadingFrom(line);
             // Add missing leading spaces to line comments: `//foo` -> `// foo`.
             Matcher matcher = LINE_COMMENT_MISSING_SPACE_PREFIX.matcher(line);
             if (matcher.find()) {

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/FormatterTest.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -441,6 +442,28 @@ public final class FormatterTest {
                 + "  /// one long incredibly unbroken sentence moving from topic to topic so that no-one"
                 + " had a chance\n"
                 + "  /// to interrupt;\n"
+                + "  void m() {}\n"
+                + "}\n";
+        assertThat(Formatter.create().formatSource(input)).isEqualTo(expected);
+    }
+
+    @Test
+    public void wrapMarkdownDocstringRunKeepsTheSlashPrefix() throws Exception {
+        // javac returns a run of `///` lines as one comment token from JDK 23 on; before that each line is its
+        // own token and the wrapped line is always the first of its token, which is never misread.
+        Assumptions.assumeTrue(
+                Formatter.getRuntimeVersion() >= 23, "a `///` run is one comment token only from JDK 23 on");
+        String input = "class T {\n"
+                + "  /// Summary line.\n"
+                + "  /// one long incredibly unbroken sentence moving from topic to topic so that no-one had a"
+                + " chance to interrupt; @Deprecated\n"
+                + "  void m() {}\n"
+                + "}\n";
+        String expected = "class T {\n"
+                + "  /// Summary line.\n"
+                + "  /// one long incredibly unbroken sentence moving from topic to topic so that no-one had a"
+                + " chance\n"
+                + "  /// to interrupt; @Deprecated\n"
                 + "  void m() {}\n"
                 + "}\n";
         assertThat(Formatter.create().formatSource(input)).isEqualTo(expected);

--- a/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavaCommentsHelperTest.java
+++ b/palantir-java-format/src/test/java/com/palantir/javaformat/java/JavaCommentsHelperTest.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.javaformat.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.javaformat.java.JavaFormatterOptions.Style;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests comment rewriting against the comment toks javac produces, without needing the JDK that produces them. From
+ * JDK 23 on, a run of {@code ///} markdown lines (JEP 467) arrives as a single comment tok whose lines after the first
+ * carry their source indentation; before 23 each {@code //} line is its own tok. Building the tok directly covers the
+ * multi-line shape on any JDK.
+ */
+public class JavaCommentsHelperTest {
+
+    private static final int COLUMN = 4;
+
+    /** Rewrites a comment tok that sits at column {@link #COLUMN}, as javac 23 or later would report it. */
+    private static String rewrite(String commentText, Style style) {
+        JavaFormatterOptions options =
+                JavaFormatterOptions.builder().style(style).build();
+        JavaInput.Tok tok = new JavaInput.Tok(0, commentText, commentText, 0, COLUMN, false, null);
+        return new JavaCommentsHelper("\n", options).rewrite(tok, options.maxLineLength(), COLUMN);
+    }
+
+    /** A run of {@code ///} lines, indented as javac reports it, with {@code body} as the second line's text. */
+    private static String markdownRun(String body) {
+        return "/// Summary line.\n" + " ".repeat(COLUMN) + "/// " + body;
+    }
+
+    private static String wordsOfLength(int length) {
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < length) {
+            sb.append(sb.length() == 0 ? "" : " ").append("word");
+        }
+        return sb.substring(0, length);
+    }
+
+    @Test
+    public void everyWrappedLineKeepsTheSlashPrefix() {
+        // Before the fix the prefix was read from the untrimmed continuation line, came back empty, and the
+        // overflow was emitted as bare code -- which stops being a comment at all.
+        String rewritten = rewrite(markdownRun(wordsOfLength(140) + " @Deprecated"), Style.PALANTIR);
+
+        assertThat(rewritten).contains("\n");
+        assertThat(rewritten.lines()).allSatisfy(line -> assertThat(line.trim()).startsWith("///"));
+        assertThat(rewritten).doesNotContain("\n    @Deprecated");
+    }
+
+    @Test
+    public void aContinuationLineAtTheLimitIsNotWrapped() {
+        // The line's visual width is COLUMN + its trimmed length, so the budget is maxLineLength - COLUMN.
+        int budget = Style.PALANTIR.maxLineLength() - COLUMN;
+        String body = wordsOfLength(budget - "/// ".length());
+
+        assertThat(rewrite(markdownRun(body), Style.PALANTIR).lines()).hasSize(2);
+    }
+
+    @Test
+    public void aContinuationLineOverTheLimitIsWrapped() {
+        int budget = Style.PALANTIR.maxLineLength() - COLUMN;
+        String body = wordsOfLength(budget - "/// ".length() + 1);
+
+        assertThat(rewrite(markdownRun(body), Style.PALANTIR).lines()).hasSize(3);
+    }
+
+    @Test
+    public void anUnbreakableTokenIsLeftLong() {
+        // There is nowhere to break, so the line stays over the limit rather than becoming an empty `///`
+        // followed by a bare URL.
+        String url = "https://example.com/" + "a".repeat(Style.PALANTIR.maxLineLength());
+
+        String rewritten = rewrite(markdownRun(url), Style.PALANTIR);
+
+        assertThat(rewritten.lines()).hasSize(2);
+        assertThat(rewritten).contains("/// " + url);
+    }
+
+    @Test
+    public void theMissingSpaceRuleAppliesToEveryLineOfTheRun() {
+        // Otherwise the same source formats differently depending on whether the running JDK hands the run
+        // over as one tok (23 and later) or as one tok per line.
+        String rewritten = rewrite("///Summary line.\n" + " ".repeat(COLUMN) + "///More text.", Style.PALANTIR);
+
+        assertThat(rewritten).isEqualTo("/// Summary line.\n" + " ".repeat(COLUMN) + "/// More text.");
+    }
+
+    @Test
+    public void anOrdinaryLineCommentStillWraps() {
+        String rewritten = rewrite("// " + wordsOfLength(140), Style.PALANTIR);
+
+        assertThat(rewritten.lines()).hasSize(2);
+        assertThat(rewritten.lines()).allSatisfy(line -> assertThat(line.trim()).startsWith("// "));
+    }
+}


### PR DESCRIPTION
## Before this PR

From JDK 23 on, javac returns a run of `///` markdown doc lines (JEP 467) as a **single** comment token, so every line after the first still carries its source indentation when `JavaCommentsHelper.wrapLineComments` sees it. Two lines there then go wrong:

```java
// JavaCommentsHelper.java
String prefix = lineCommentPrefix(line);                       // reads '/' from index 0 of "    /// foo" -> ""
while (line.length() + column0 > options.maxLineLength()) {     // counts the indentation twice
```

The wrapped remainder is emitted with no `///` at all. In Palantir style the result **compiles**, which is the dangerous part:

```java
class P1 {
    /// Summary line.
    /// This second markdown line is long enough to overflow the palantir one hundred twenty column limit @Deprecated
    void f() {}
}
```

formats to

```java
class P1 {
    /// Summary line.
    /// This second markdown line is long enough to overflow the palantir one hundred twenty column limit
    @Deprecated
    void f() {}
}
```

`javap -v` goes from 0 `Deprecated` markers to 4, `javac` exits 0, and nothing downstream notices that the formatter deprecated a method. In Google style the same input produces output that does **not** compile (`illegal start of type`), and formatting it again cannot parse it — so `format` followed by `formatDiagnose`/`spotlessCheck` fails on a file the formatter just wrote. Reproduced on JDK 23, 25 and 26, in full format and through `formatSourceAndFixImports`, which is what the Gradle plugin's Spotless step reaches via `FormatterService`.

It needs the `///` block to be indented: at `column0 == 0` the prefix is found correctly, which is why a top-level case does not reproduce it.

`git log -S lineCommentPrefix` dates the `prefix` variable to #1672. Before that commit the same input produced `// limit @Deprecated` — wrong documentation, but valid Java. #1672's test uses a single `///` line, which is always line 0 of its token and always gets the right prefix, and it runs on the JDK 21 test task where the multi-line path is unreachable. For reference, google-java-format still hardcodes `"// "` here.

## After this PR

The prefix and the width budget come from the trimmed line — which `indentLineComments` trims and re-indents anyway — so:

```diff
     /// Summary line.
-    /// …one hundred twenty column limit
-    @Deprecated
+    /// …one hundred and twenty column limit for sure
+    /// @Deprecated
     void f() {}
```

- a continuation line keeps `///` when it wraps;
- a line at the column limit is no longer wrapped (the indentation was being counted twice);
- an unbreakable token, e.g. a long URL, is left long instead of producing an empty `///` followed by bare text;
- `///foo` → `/// foo` now applies to every line of the run, so the same source no longer formats differently depending on whether the running JDK hands the run over as one token or as one token per line.

## Tests

`JavaCommentsHelperTest` builds the multi-line comment token directly instead of going through javac, so **the JDK 21 test task covers a bug only a JDK 23 or later parser can produce**. Four of its six tests fail without the one-line change; the other two are regression guards for ordinary `//` wrapping. The end-to-end case in `FormatterTest` is gated at 23 with an assumption.

Verified by hand with the CLI on JDK 25 and 26: the `@Deprecated` case stays inside the comment, `javap -v` reports 0 `Deprecated` markers, the output compiles, and formatting it again is a fixed point. `./gradlew build` passes.

## Not in this PR

The same investigation found more `///` issues, all pre-existing and none of them code-corrupting. Listing them so they are not lost; happy to take any of them in follow-ups:

- reflowing a line inside a fenced block, a `{@snippet}`, a markdown table or a link-reference definition changes the rendered markdown even when the wrap is syntactically safe — those regions should not be reflowed at all;
- `///Summary.` gaining a space raises the run's common indentation, which turns an indented code block into a paragraph (confirmed in the rendered HTML);
- two trailing spaces, a CommonMark hard line break, are trimmed away;
- `doc/Comment.java:75-77` holds a second, unguarded copy of the missing-space rule, which also breaks a trailing `//noinspection` or `//$NON-NLS-1$` — the exclusion regex in `JavaCommentsHelper` was written to prevent exactly that;
- on JDK 21/22 an import referenced only from a markdown link (`/// see [List]`) is removed as unused, because `getDocCommentTree` returns nothing for `///` there.

Split out of #1707, whose reviewer asked for these wrapping bugs to be a separate change. This PR does not depend on it and touches no file it touches.

---

**AI Disclosure:** This pull request was prepared with the assistance of Claude Code — the investigation, the fix, the tests, and this description — and reviewed by me before submission.
